### PR TITLE
Renamed getMirroredDocumentDefinitions to getMirroredObjectDefinitions in YmerConverterTestBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ public class ExampleMirrorConverterTest extends YmerConverterTestBase {
 	}
 
 	@Override
-	protected Collection<MirroredObjectDefinition<?>> getMirroredDocumentDefinitions() {
+	protected Collection<MirroredObjectDefinition<?>> getMirroredObjectDefinitions() {
 		return ExampleMirrorFactory.getDefinitions();
 	}
 

--- a/examples/example-pu/src/test/java/example/mirror/ExampleMirrorConverterTest.java
+++ b/examples/example-pu/src/test/java/example/mirror/ExampleMirrorConverterTest.java
@@ -34,7 +34,7 @@ public class ExampleMirrorConverterTest extends YmerConverterTestBase {
 	}
 
 	@Override
-	protected Collection<MirroredObjectDefinition<?>> getMirroredDocumentDefinitions() {
+	protected Collection<MirroredObjectDefinition<?>> getMirroredObjectDefinitions() {
 		return ExampleMirrorFactory.getDefinitions();
 	}
 

--- a/ymer-test/src/main/java/com/avanza/ymer/YmerConverterTestBase.java
+++ b/ymer-test/src/main/java/com/avanza/ymer/YmerConverterTestBase.java
@@ -38,9 +38,6 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 
-import com.avanza.ymer.DocumentConverter;
-import com.avanza.ymer.MirroredObject;
-import com.avanza.ymer.MirroredObjects;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 
@@ -146,10 +143,10 @@ public abstract class YmerConverterTestBase {
     }
 	
 	protected MirroredObjects getMirroredObjects() {
-		return new MirroredObjects(getMirroredDocumentDefinitions().stream());
+		return new MirroredObjects(getMirroredObjectDefinitions().stream());
 	}
 	
-	protected abstract Collection<MirroredObjectDefinition<?>> getMirroredDocumentDefinitions();
+	protected abstract Collection<MirroredObjectDefinition<?>> getMirroredObjectDefinitions();
 
 	protected abstract MongoConverter createMongoConverter(MongoDbFactory mongoDbFactory);
 	

--- a/ymer-test/src/test/java/com/avanza/ymer/YmerConverterTestBaseTest.java
+++ b/ymer-test/src/test/java/com/avanza/ymer/YmerConverterTestBaseTest.java
@@ -173,7 +173,7 @@ public class YmerConverterTestBaseTest {
 		}
 
 		@Override
-		protected Collection<MirroredObjectDefinition<?>> getMirroredDocumentDefinitions() {
+		protected Collection<MirroredObjectDefinition<?>> getMirroredObjectDefinitions() {
 			DocumentPatch[] patches = {};
 			return Arrays.asList(MirroredObjectDefinition.create(TestSpaceObjectWithEmptyCollection.class).documentPatches(patches));
 		}
@@ -192,7 +192,7 @@ public class YmerConverterTestBaseTest {
 		}
 
 		@Override
-		protected Collection<MirroredObjectDefinition<?>> getMirroredDocumentDefinitions() {
+		protected Collection<MirroredObjectDefinition<?>> getMirroredObjectDefinitions() {
 			DocumentPatch[] patches = {};
 			return Arrays.asList(MirroredObjectDefinition.create(TestSpaceObjectWithEmptyMap.class).documentPatches(patches));
 		}
@@ -211,7 +211,7 @@ public class YmerConverterTestBaseTest {
 		}
 
 		@Override
-		protected Collection<MirroredObjectDefinition<?>> getMirroredDocumentDefinitions() {
+		protected Collection<MirroredObjectDefinition<?>> getMirroredObjectDefinitions() {
 			DocumentPatch[] patches = {};
 			return Arrays.asList(MirroredObjectDefinition.create(TestSpaceObject.class).documentPatches(patches));
 		}
@@ -230,7 +230,7 @@ public class YmerConverterTestBaseTest {
 		}
 		
 		@Override
-		protected Collection<MirroredObjectDefinition<?>> getMirroredDocumentDefinitions() {
+		protected Collection<MirroredObjectDefinition<?>> getMirroredObjectDefinitions() {
 			DocumentPatch[] patches = {};
 			return Arrays.asList(MirroredObjectDefinition.create(TestSpaceObjectWithoutSpringDataIdAnnotation.class).documentPatches(patches));
 		}


### PR DESCRIPTION
Method in YmerConverterTestBase is incorrectly named getMirroredDocumentDefinitions (from persistence-support). It should be named getMirroredObjectDefinitions as in YmerMigrationTestBase.