### PR TITLE
TP-360: enable reading from secondaries

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/DocumentDb.java
+++ b/ymer/src/main/java/com/avanza/ymer/DocumentDb.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -49,11 +50,15 @@ final class DocumentDb {
 	}
 	
 	DocumentCollection getCollection(String name) {
-		return provider.get(name);
+		return getCollection(name, null);
+	}
+
+	DocumentCollection getCollection(String name, ReadPreference readPreference) {
+		return provider.get(name, readPreference);
 	}
 	
 	interface Provider {
-		DocumentCollection get(String name);
+		DocumentCollection get(String name, ReadPreference readPreference);
 	}
 	
 	private static final class MongoDocumentDb implements DocumentDb.Provider {
@@ -74,9 +79,9 @@ final class DocumentDb {
 		}
 
 		@Override
-		public DocumentCollection get(String name) {
+		public DocumentCollection get(String name, ReadPreference readPreference) {
 			DBCollection collection = mongoDb.getCollection(name);
-			collection.setReadPreference(readPreference);
+			collection.setReadPreference(Optional.ofNullable(readPreference).orElse(this.readPreference));
 			return new MongoDocumentCollection(collection);
 		}
 	}

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
@@ -18,6 +18,7 @@ package com.avanza.ymer;
 import com.gigaspaces.annotation.pojo.SpaceId;
 import com.gigaspaces.annotation.pojo.SpaceRouting;
 import com.mongodb.BasicDBObject;
+import com.mongodb.ReadPreference;
 
 import java.lang.reflect.Method;
 /**
@@ -38,6 +39,7 @@ final class MirroredObject<T> {
 	private final boolean keepPersistent;
     private final String collectionName;
 	private final TemplateFactory customInitialLoadTemplateFactory;
+	private final ReadPreference readPreference;
 
 	public MirroredObject(MirroredObjectDefinition<T> definition, MirroredObjectDefinitionsOverride override) {
 		this.patchChain = definition.createPatchChain();
@@ -48,6 +50,7 @@ final class MirroredObject<T> {
         this.keepPersistent = definition.keepPersistent();
         this.collectionName = definition.collectionName();
         this.customInitialLoadTemplateFactory = definition.customInitialLoadTemplateFactory();
+        this.readPreference = definition.getReadPreference();
 	}
 
 	private RoutingKeyExtractor findRoutingKeyMethod(Class<T> mirroredType) {
@@ -192,6 +195,10 @@ final class MirroredObject<T> {
 
 	boolean loadDocumentsRouted() {
 		return loadDocumentsRouted;
+	}
+
+	ReadPreference getReadPreference() {
+		return readPreference;
 	}
 
 	public boolean keepPersistent() {

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinition.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinition.java
@@ -35,6 +35,9 @@ import org.springframework.data.mongodb.MongoCollectionUtils;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
+
+import com.mongodb.ReadPreference;
+
 /**
  * Holds information about one mirrored space object type.
  *
@@ -51,6 +54,7 @@ public final class MirroredObjectDefinition<T> {
 	private boolean loadDocumentsRouted = false;
 	private boolean keepPersistent = false;
 	private TemplateFactory customInitialLoadTemplateFactory;
+	private ReadPreference readPreference;
 
 	public MirroredObjectDefinition(Class<T> mirroredType) {
 		this.mirroredType = Objects.requireNonNull(mirroredType);
@@ -128,6 +132,14 @@ public final class MirroredObjectDefinition<T> {
 		return this;
 	}
 
+	/**
+	 * Sets the read preference for queries against documents in this collection.
+	 */
+	public MirroredObjectDefinition<T> withReadPreference(ReadPreference readPreference) {
+		this.readPreference = Objects.requireNonNull(readPreference);
+		return this;
+	}
+
 	boolean loadDocumentsRouted() {
 		return this.loadDocumentsRouted;
 	}
@@ -148,6 +160,10 @@ public final class MirroredObjectDefinition<T> {
 	String collectionName() {
 		return Optional.ofNullable(this.collectionName)
 						  .orElseGet(() -> MongoCollectionUtils.getPreferredCollectionName(mirroredType));
+	}
+
+	ReadPreference getReadPreference() {
+		return readPreference;
 	}
 
 	public static <T> MirroredObjectDefinition<T> create(Class<T> mirroredType) {

--- a/ymer/src/main/java/com/avanza/ymer/SpaceMirrorContext.java
+++ b/ymer/src/main/java/com/avanza/ymer/SpaceMirrorContext.java
@@ -53,7 +53,10 @@ final class SpaceMirrorContext {
 		this.numParallelCollections = numParallelCollections;
 
 		for (MirroredObject<?> mirroredObject : mirroredObjects.getMirroredObjects()) {
-			DocumentCollection documentCollection = documentDb.getCollection(mirroredObject.getCollectionName());
+			DocumentCollection documentCollection = documentDb.getCollection(
+					mirroredObject.getCollectionName(),
+					mirroredObject.getReadPreference()
+			);
 			this.documentCollectionByMirroredType.put(mirroredObject.getMirroredType(), documentCollection);
 		}
 	}

--- a/ymer/src/main/java/com/avanza/ymer/YmerFactory.java
+++ b/ymer/src/main/java/com/avanza/ymer/YmerFactory.java
@@ -25,6 +25,7 @@ import org.springframework.data.mongodb.core.convert.MongoConverter;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 /**
  * @author Elias Lindholm (elilin)
@@ -36,7 +37,7 @@ public final class YmerFactory {
 		@Override
 		public void onMirrorException(Exception e, MirrorOperation failedOperation, Object[] failedObjects) {}
 	};
-	private final ReadPreference readPreference = ReadPreference.primary();
+	private ReadPreference readPreference = ReadPreference.primary();
 	private boolean exportExceptionHandleMBean = true;
 	private Set<Plugin> plugins = Collections.emptySet();
 	private int numParallelCollections = 1;
@@ -86,6 +87,17 @@ public final class YmerFactory {
 			throw new IllegalArgumentException("numParallelCollections must be a positive integer, was numParallelCollections=" + numParallelCollections + "!");
 		}
 		this.numParallelCollections = numParallelCollections;
+	}
+
+	/**
+	 * Sets the read preference for queries against all document collections.
+	 * Use {@link ReadPreference#secondaryPreferred} or
+	 * {@link ReadPreference#primaryPreferred} to enable reads from mongo
+	 * secondaries. Default is {@link ReadPreference#primary}.
+	 */
+	public YmerFactory withReadPreference(ReadPreference readPreference) {
+		this.readPreference = Objects.requireNonNull(readPreference);
+		return this;
 	}
 
 	public SpaceDataSource createSpaceDataSource() {

--- a/ymer/src/test/java/com/avanza/ymer/FakeDocumentDb.java
+++ b/ymer/src/test/java/com/avanza/ymer/FakeDocumentDb.java
@@ -17,12 +17,14 @@ package com.avanza.ymer;
 
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.mongodb.ReadPreference;
+
 public class FakeDocumentDb implements DocumentDb.Provider {
 
-	private ConcurrentHashMap<String, FakeDocumentCollection> collectionByName = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, FakeDocumentCollection> collectionByName = new ConcurrentHashMap<>();
 	
 	@Override
-	public DocumentCollection get(String name) {
+	public DocumentCollection get(String name, ReadPreference readPreference) {
 		FakeDocumentCollection documentCollection = new FakeDocumentCollection();
 		collectionByName.putIfAbsent(name, documentCollection);
 		return collectionByName.get(name);

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
@@ -263,7 +263,7 @@ public class MirroredObjectWriterTest {
 	}
 
 	private DocumentDb throwsOnUpdateDocumentDb() {
-		return DocumentDb.create(name -> new FakeDocumentCollection() {
+		return DocumentDb.create((name, readPreference) -> new FakeDocumentCollection() {
 			@Override
 			public void update(DBObject dbObject) {
 				throw new RuntimeException();

--- a/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
@@ -159,7 +159,7 @@ public class MongoDocumentCollectionTest extends DocumentCollectionContract {
 		assertEquals(2, loadedSpaceObjects.size());
 	}
 
-	private static class FakeSpaceObject {
+	static class FakeSpaceObject {
 		private final Integer id;
 		private final String value;
 		private FakeSpaceObject(Integer id, String value) {

--- a/ymer/src/test/java/com/avanza/ymer/YmerFactoryTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/YmerFactoryTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Spliterator;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.openspaces.core.cluster.ClusterInfo;
+import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import com.avanza.ymer.MongoDocumentCollectionTest.FakeSpaceObject;
+import com.mongodb.BasicDBList;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.ReadPreference;
+
+public class YmerFactoryTest {
+	private final DB db = mock(DB.class);
+	private final DBCollection fakeSpaceObjectCollection = createMockedEmptyCollection();
+	private final DBCollection testSpaceObjectCollection = createMockedEmptyCollection();
+
+	@Before
+	public void beforeEachTest() {
+		when(db.getCollection("fakeSpaceObject")).thenReturn(fakeSpaceObjectCollection);
+		when(db.getCollection("testSpaceObject")).thenReturn(testSpaceObjectCollection);
+	}
+
+	@Test
+	public void shouldSetReadPreferenceOnCreatedDocumentCollections() {
+		// Arrange
+		final Collection<MirroredObjectDefinition<?>> definitions = Arrays.asList(
+				MirroredObjectDefinition.create(TestSpaceObject.class),
+				MirroredObjectDefinition.create(FakeSpaceObject.class)
+						.withReadPreference(ReadPreference.secondaryPreferred())
+		);
+		final YmerFactory factory = new YmerFactory(createMockedFactory(db), mock(MongoConverter.class), definitions)
+				.withReadPreference(ReadPreference.primaryPreferred());
+		final YmerSpaceDataSource ysds = (YmerSpaceDataSource) factory.createSpaceDataSource();
+		ysds.setClusterInfo(new ClusterInfo("schema", 1, 1, 1, 1));
+
+		// Act
+		ysds.initialDataLoad().forEachRemaining(new ArrayList<>()::add);
+
+		// Assert
+		final ArgumentCaptor<ReadPreference> testSpaceReadPreferenceCaptor = ArgumentCaptor.forClass(ReadPreference.class);
+		final ArgumentCaptor<ReadPreference> fakeSpaceReadPreferenceCaptor = ArgumentCaptor.forClass(ReadPreference.class);
+		verify(testSpaceObjectCollection).setReadPreference(testSpaceReadPreferenceCaptor.capture());
+		verify(fakeSpaceObjectCollection).setReadPreference(fakeSpaceReadPreferenceCaptor.capture());
+
+		// We have explicitly set the readPreference on the "FakeSpaceObject" collection,
+		// so this should have been used for that:
+		assertThat(fakeSpaceReadPreferenceCaptor.getValue(), equalTo(ReadPreference.secondaryPreferred()));
+		// But for the "TestSpaceObject" collection, we should use the default
+		// from YmerFactory.
+		assertThat(testSpaceReadPreferenceCaptor.getValue(), equalTo(ReadPreference.primaryPreferred()));
+	}
+
+	private MongoDbFactory createMockedFactory(DB db) {
+		final MongoDbFactory mongoDbFactory = mock(MongoDbFactory.class);
+		when(mongoDbFactory.getDb()).thenReturn(db);
+		return mongoDbFactory;
+	}
+
+	private DBCollection createMockedEmptyCollection() {
+		final DBCollection collection = mock(DBCollection.class);
+		doReturn(new DBCursor(collection, new BasicDBList(), null, null) {
+			@Override
+			public boolean hasNext() {
+				return false;
+			}
+
+			@Override
+			public Spliterator<DBObject> spliterator() {
+				return Stream.<DBObject>empty().spliterator();
+			}
+		}).when(collection).find();
+		return collection;
+	}
+}


### PR DESCRIPTION
Adds two new abilities:
* Configure the `YmerFactory` so that all document queries may be read from mongo secondaries.
* Configure each `MirroredObjectDefinition` with an explicit readpreference, so that documents may be read from mongo secondaries

This will be used in cases where a lot of data needs to be loaded, and we want to reduce the load on the primary mongo instance.