### PR TITLE
TP-394: Fix failing test YmerSpaceDataSourceTest

### DIFF
--- a/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
+++ b/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
@@ -15,6 +15,7 @@
  */
 package com.avanza.ymer;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,12 +37,12 @@ class FakeDocumentCollection implements DocumentCollection {
 
 	@Override
 	public Stream<DBObject> findAll(SpaceObjectFilter<?> filter) {
-		return collection.stream();
+		return new ArrayList<>(collection).stream();
 	}
 
 	@Override
 	public Stream<DBObject> findAll() {
-		return collection.stream();
+		return new ArrayList<>(collection).stream();
 	}
 
 	@Override


### PR DESCRIPTION
* Prevents the following test failure:
```
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.122 s <<< FAILURE! - in com.avanza.ymer.YmerSpaceDataSourceTest
[ERROR] documentsMustNotBeWrittenToDbBeforeAllElementsAreLoaded(com.avanza.ymer.YmerSpaceDataSourceTest) Time elapsed: 0.01 s <<< FAILURE!
	java.lang.AssertionError: expected:<1> but was:<2>
	at com.avanza.ymer.YmerSpaceDataSourceTest.documentsMustNotBeWrittenToDbBeforeAllElementsAreLoaded(YmerSpaceDataSourceTest.java:73)
```

The reason for the test previously failing is as follows:
* `YmerSpaceDataSource::load` calls `documentLoader.streamAllObjects()`, that returns a stream of all documents.
* This stream is traversed, and each object gets passed to `createPatchedDocumentWriteBack`, which in turn calls `doWriteBackPatchedDocument`.
* `doWriteBackPatchedDocument` makes changes to the collection.
*  Making changes to the collection while the stream is not fully materialized may have unintended side-effects.

This commit therefore resolves the issue by returning a stream of a copy of the collection during the tests, instead of a stream to the collection that might be updated.