### PR TITLE
TP-419: Added Read- and WriteConverter for java.time.Instant with nano precision

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/support/JavaInstantReadConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/JavaInstantReadConverter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer.support;
+
+import java.time.Instant;
+
+import org.springframework.core.convert.converter.Converter;
+
+public class JavaInstantReadConverter implements Converter<String, Instant> {
+    @Override
+    public Instant convert(String value) {
+        return Instant.parse(value);
+    }
+}

--- a/ymer/src/main/java/com/avanza/ymer/support/JavaInstantReadConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/JavaInstantReadConverter.java
@@ -16,12 +16,13 @@
 package com.avanza.ymer.support;
 
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 import org.springframework.core.convert.converter.Converter;
 
 public class JavaInstantReadConverter implements Converter<String, Instant> {
     @Override
     public Instant convert(String value) {
-        return Instant.parse(value);
+        return DateTimeFormatter.ISO_INSTANT.parse(value, Instant::from);
     }
 }

--- a/ymer/src/main/java/com/avanza/ymer/support/JavaInstantWriteConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/JavaInstantWriteConverter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer.support;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.core.convert.converter.Converter;
+
+public class JavaInstantWriteConverter implements Converter<Instant, String> {
+    @Override
+    public String convert(Instant instant) {
+        return instant.atZone(ZoneId.systemDefault())
+                      .format(DateTimeFormatter.ISO_INSTANT);
+    }
+}

--- a/ymer/src/main/java/com/avanza/ymer/support/JavaInstantWriteConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/JavaInstantWriteConverter.java
@@ -16,7 +16,6 @@
 package com.avanza.ymer.support;
 
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 import org.springframework.core.convert.converter.Converter;
@@ -24,7 +23,6 @@ import org.springframework.core.convert.converter.Converter;
 public class JavaInstantWriteConverter implements Converter<Instant, String> {
     @Override
     public String convert(Instant instant) {
-        return instant.atZone(ZoneId.systemDefault())
-                      .format(DateTimeFormatter.ISO_INSTANT);
+        return DateTimeFormatter.ISO_INSTANT.format(instant);
     }
 }

--- a/ymer/src/test/java/com/avanza/ymer/support/JavaInstantConverterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/support/JavaInstantConverterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer.support;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class JavaInstantConverterTest {
+
+    private JavaInstantReadConverter javaInstantReadConverter;
+    private JavaInstantWriteConverter javaInstantWriteConverter;
+
+    @Before
+    public void test() {
+        javaInstantReadConverter = new JavaInstantReadConverter();
+        javaInstantWriteConverter = new JavaInstantWriteConverter();
+    }
+
+    @Test
+    public void shouldConvertSuccessfully() {
+        // Given
+        Instant expected = ZonedDateTime
+                .of(LocalDateTime.of(2020, 1, 15, 13, 37, 17, 123456789),
+                    ZoneId.of("Europe/Stockholm"))
+                .toInstant();
+
+        // When
+        Instant actual = javaInstantReadConverter.convert(javaInstantWriteConverter.convert(expected));
+
+        // Then
+        assertThat(actual, is(expected));
+    }
+
+}

--- a/ymer/src/test/java/com/avanza/ymer/support/JavaInstantReadConverterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/support/JavaInstantReadConverterTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer.support;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class JavaInstantReadConverterTest {
+
+    private JavaInstantReadConverter javaInstantReadConverter;
+
+    @Before
+    public void setup() {
+        javaInstantReadConverter = new JavaInstantReadConverter();
+    }
+
+    @Test
+    public void shouldConvertISOInstantValueIntoInstantWithNanoPrecision() {
+        // Given
+        Instant expected =
+                LocalDateTime
+                .of(2020, 7, 29, 15, 43, 56, 863000000)
+                .toInstant(ZoneOffset.UTC);
+
+        // When
+        Instant actual = javaInstantReadConverter.convert("2020-07-29T15:43:56.863Z");
+
+        // Then
+        assertThat(actual.getEpochSecond(), is(expected.getEpochSecond()));
+        assertThat(actual.getNano(), is(expected.getNano()));
+    }
+
+}

--- a/ymer/src/test/java/com/avanza/ymer/support/JavaInstantWriteConverterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/support/JavaInstantWriteConverterTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer.support;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class JavaInstantWriteConverterTest {
+
+    private JavaInstantWriteConverter javaInstantWriteConverter;
+
+    @Before
+    public void setup() {
+        javaInstantWriteConverter = new JavaInstantWriteConverter();
+    }
+
+    @Test
+    public void shouldConvertInstantIntoISOInstantValueWithNanoPrecision() {
+        //Given
+        String expected = "2020-07-01T13:37:17.000000470Z";
+        Instant instant =
+                LocalDateTime.of(2020, 7, 1, 13, 37, 17, 470)
+                .toInstant(ZoneOffset.UTC);
+
+        // When
+        String actual = javaInstantWriteConverter.convert(instant);
+
+        // Then
+        assertThat(actual, is(expected));
+    }
+
+}


### PR DESCRIPTION
Notes to reviewer:
* Instant will always use the UTC time zone, meaning that all strings written as a `String` will always been in UTC format, and it is up to the user of a given `Instant` to set the appropriate time zone. 
* The converters need to be added explicit as custom converters in a given space/PU that want to use them. 