### PR TITLE
TP-426: Use different interfaces for DocumentPatch

### DIFF
--- a/examples/example-pu/src/main/java/example/mirror/SpaceFruitV1ToV2Patch.java
+++ b/examples/example-pu/src/main/java/example/mirror/SpaceFruitV1ToV2Patch.java
@@ -15,7 +15,6 @@
  */
 package example.mirror;
 
-import org.bson.Document;
 import com.avanza.ymer.DocumentPatch;
 import com.mongodb.BasicDBObject;
 
@@ -24,11 +23,6 @@ public class SpaceFruitV1ToV2Patch implements DocumentPatch {
 	@Override
 	public void apply(BasicDBObject dbObject) {
 		dbObject.put("organic", false);
-	}
-
-	@Override
-	public void apply(Document document) {
-		document.put("organic", false);
 	}
 
 	@Override

--- a/ymer-test/src/test/java/com/avanza/ymer/YmerMigrationTestBaseTest.java
+++ b/ymer-test/src/test/java/com/avanza/ymer/YmerMigrationTestBaseTest.java
@@ -45,11 +45,6 @@ public class YmerMigrationTestBaseTest {
 			}
 
 			@Override
-			public void apply(Document document) {
-				document.put("baz", "baz");
-			}
-
-			@Override
 			public int patchedVersion() {
 				return 1;
 			}
@@ -78,11 +73,6 @@ public class YmerMigrationTestBaseTest {
 			@Override
 			public void apply(BasicDBObject dbObject) {
 				dbObject.put("baz", "baz");
-			}
-
-			@Override
-			public void apply(Document document) {
-				document.put("baz", "baz");
 			}
 
 			@Override
@@ -122,11 +112,6 @@ public class YmerMigrationTestBaseTest {
 			}
 
 			@Override
-			public void apply(Document document) {
-				document.put("bar", "bar");
-			};
-
-			@Override
 			public int patchedVersion() {
 				return 1;
 			}
@@ -134,11 +119,6 @@ public class YmerMigrationTestBaseTest {
 			@Override
 			public void apply(BasicDBObject dbObject) {
 				dbObject.put("baz", "baz");
-			}
-
-			@Override
-			public void apply(Document document) {
-				document.put("baz", "baz");
 			}
 
 			@Override

--- a/ymer/src/main/java/com/avanza/ymer/BsonDocumentPatch.java
+++ b/ymer/src/main/java/com/avanza/ymer/BsonDocumentPatch.java
@@ -16,38 +16,25 @@
 package com.avanza.ymer;
 
 import org.bson.Document;
-import com.mongodb.BasicDBObject;
-/**
- * A DocumentPatch patches a given document from one version to the next. <p>
- * 
- * @author Elias Lindholm (elilin)
- *
- */
-public interface DocumentPatch extends BsonDocumentPatch {
-	
+
+public interface BsonDocumentPatch {
+
 	/**
 	 * Applies this patch to the given document. <p>
-	 * 
-	 * The patch should read the object for current state, and mutate it 
-	 * to reflect the patch. 
-	 * 
-	 * @param dbObject
+	 *
+	 * The patch should read the object for current state, and mutate it
+	 * to reflect the patch.
+	 *
+	 * @param document
 	 */
-	void apply(BasicDBObject dbObject);
-
-	default void apply(Document document) {
-		BasicDBObject dbo = new BasicDBObject(document);
-		apply(dbo);
-		document.putAll(dbo);
-	}
+	void apply(Document document);
 
 	/**
-	 * Returns the version that this patch applies to. A DocumentPatch only applies 
+	 * Returns the version that this patch applies to. A DocumentPatch only applies
 	 * to a single version. A DocumentPatch is expected to patch the document
 	 * to the next version. <p>
-	 * 
+	 *
 	 * @return
 	 */
 	int patchedVersion();
-	
 }

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
@@ -213,7 +213,7 @@ final class MirroredObject<T> {
 		if (!requiresPatching(document)) {
 			throw new IllegalArgumentException("Document does not require patching: " + document.toString());
 		}
-		DocumentPatch patch = this.patchChain.getPatch(getDocumentVersion(document));
+		BsonDocumentPatch patch = this.patchChain.getPatch(getDocumentVersion(document));
 		patch.apply(document);
 		setDocumentVersion(document, patch.patchedVersion() + 1);
 	}

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinition.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinition.java
@@ -48,7 +48,7 @@ public final class MirroredObjectDefinition<T> {
 
 	private final Class<T> mirroredType;
 	private String collectionName;
-	private DocumentPatch[] patches = new DocumentPatch[0];
+	private BsonDocumentPatch[] patches = new BsonDocumentPatch[0];
 	private boolean excludeFromInitialLoad = false;
 	private boolean writeBackPatchedDocuments = true;
 	private boolean loadDocumentsRouted = false;
@@ -69,7 +69,7 @@ public final class MirroredObjectDefinition<T> {
 		return this;
     }
 
-    public MirroredObjectDefinition<T> documentPatches(DocumentPatch... patches) {
+    public MirroredObjectDefinition<T> documentPatches(BsonDocumentPatch... patches) {
     	this.patches = patches;
     	return this;
 	}

--- a/ymer/src/test/java/com/avanza/ymer/DocumentPatchChainTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/DocumentPatchChainTest.java
@@ -35,7 +35,7 @@ public class DocumentPatchChainTest {
 
 		DocumentPatchChain<Object> patchChain = new DocumentPatchChain<>(Object.class, Arrays.asList(v2ToV3, v1ToV2));
 		
-		Iterator<DocumentPatch> patches = patchChain.iterator();
+		var patches = patchChain.iterator();
 		assertSame(v1ToV2, patches.next());
 		assertSame(v2ToV3, patches.next());
 		assertFalse(patches.hasNext());
@@ -64,10 +64,10 @@ public class DocumentPatchChainTest {
 	}
 	
 	@Test
-	public void chaingWithThreePatches() throws Exception {
+	public void chainWithThreePatches() throws Exception {
 		DocumentPatch p1 = Mockito.mock(DocumentPatch.class);
 		DocumentPatch p2 = Mockito.mock(DocumentPatch.class);
-		DocumentPatch p3 = Mockito.mock(DocumentPatch.class);
+		BsonDocumentPatch p3 = Mockito.mock(BsonDocumentPatch.class);
 		Mockito.when(p1.patchedVersion()).thenReturn(1);
 		Mockito.when(p2.patchedVersion()).thenReturn(2);
 		Mockito.when(p3.patchedVersion()).thenReturn(3);

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectLoaderTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectLoaderTest.java
@@ -215,7 +215,7 @@ public class MirroredObjectLoaderTest {
 	public void propagatesExceptionsThrownByMigrator() throws Exception {
 		DocumentPatch[] patches = { new FakeSpaceObjectV1Patch() {
 			@Override
-			public void apply(Document document) {
+			public void apply(BasicDBObject document) {
 				throw new IllegalArgumentException("My bigest failure");
 			}
 		} };
@@ -302,11 +302,6 @@ public class MirroredObjectLoaderTest {
 		@Override
 		public void apply(BasicDBObject dbObject) {
 			dbObject.put("patched", true);
-		}
-
-		@Override
-		public void apply(Document document) {
-			document.put("patched", true);
 		}
 
 		@Override

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectTest.java
@@ -410,12 +410,6 @@ public class MirroredObjectTest {
 		}
 
 		@Override
-		public void apply(Document document) {
-			applied = true;
-			appliedPatches.add(this);
-		}
-
-		@Override
 		public int patchedVersion() {
 			return patchedVersion;
 		}

--- a/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
+++ b/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
@@ -19,14 +19,28 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import com.avanza.ymer.YmerInitialLoadIntegrationTest.TestSpaceObjectV1Patch;
+import com.avanza.ymer.YmerInitialLoadIntegrationTest.TestSpaceObjectV2Patch;
 
 public class TestSpaceMirrorObjectDefinitions  {
 
+	public static final MirroredObjectDefinition<TestSpaceObject> TEST_SPACE_OBJECT =
+			MirroredObjectDefinition.create(TestSpaceObject.class)
+					.documentPatches(new TestSpaceObjectV1Patch(), new TestSpaceObjectV2Patch());
+
+	public static final MirroredObjectDefinition<TestSpaceOtherObject> TEST_SPACE_OTHER_OBJECT =
+			MirroredObjectDefinition.create(TestSpaceOtherObject.class)
+					.writeBackPatchedDocuments(false)
+					.documentPatches(new TestSpaceObjectV1Patch());
+
+	public static final MirroredObjectDefinition<TestSpaceThirdObject> TEST_SPACE_THIRD_OBJECT =
+			MirroredObjectDefinition.create(TestSpaceThirdObject.class)
+					.documentPatches(new TestSpaceThirdObject.TestSpaceThirdObjectPatchV1());
+
 	public Collection<MirroredObjectDefinition<?>> getDefinitions() {
 		return Arrays.asList(
-				MirroredObjectDefinition.create(TestSpaceObject.class).documentPatches(new TestSpaceObjectV1Patch()),
-				MirroredObjectDefinition.create(TestSpaceOtherObject.class).writeBackPatchedDocuments(false).documentPatches(new TestSpaceObjectV1Patch()),
-				MirroredObjectDefinition.create(TestSpaceThirdObject.class).documentPatches(new TestSpaceThirdObject.TestSpaceThirdObjectPatchV1())
+				TEST_SPACE_OBJECT,
+				TEST_SPACE_OTHER_OBJECT,
+				TEST_SPACE_THIRD_OBJECT
 		);
 	}
 

--- a/ymer/src/test/java/com/avanza/ymer/TestSpaceThirdObject.java
+++ b/ymer/src/test/java/com/avanza/ymer/TestSpaceThirdObject.java
@@ -32,12 +32,6 @@ public class TestSpaceThirdObject {
 		}
 
 		@Override
-		public void apply(Document document) {
-			String name = (String) document.get("name");
-			document.put("name", "b" + name);
-		}
-
-		@Override
 		public int patchedVersion() {
 			return 1;
 		}

--- a/ymer/src/test/java/com/avanza/ymer/YmerSpaceDataSourceTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/YmerSpaceDataSourceTest.java
@@ -198,11 +198,6 @@ public class YmerSpaceDataSourceTest {
 		}
 
 		@Override
-		public void apply(Document document) {
-			document.put("patched", true);
-		}
-
-		@Override
 		public int patchedVersion() {
 			return 1;
 		}


### PR DESCRIPTION
* Adds class `BsonDocumentPatch` that is intended to replace the previous `DocumentPatch`, but that takes a `Document` instead of `BasicDBObject`.
* Adds compatibility code in `DocumentPatch` so that existing code that uses it can still work, even if the underlying data store is a `Document`.
* Adds unit tests that verify that both types of patch classes work.