### PR TITLE
TP-525: Avoid ConcurrentModificationException

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/Plugins.java
+++ b/ymer/src/main/java/com/avanza/ymer/Plugins.java
@@ -19,10 +19,10 @@ import static java.util.Collections.emptySet;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.avanza.ymer.plugin.Plugin;
 import com.avanza.ymer.plugin.PostReadProcessor;
@@ -31,8 +31,8 @@ import com.mongodb.DBObject;
 
 class Plugins {
 	private final Set<Plugin> plugins;
-	private final Map<Class<?>, PostReadProcessor> postReadProcessors = new HashMap<>();
-	private final Map<Class<?>, PreWriteProcessor> preWriteProcessors = new HashMap<>();
+	private final Map<Class<?>, PostReadProcessor> postReadProcessors = new ConcurrentHashMap<>();
+	private final Map<Class<?>, PreWriteProcessor> preWriteProcessors = new ConcurrentHashMap<>();
 
 	public static Plugins empty() {
 		return new Plugins(emptySet());
@@ -43,17 +43,12 @@ class Plugins {
 	}
 
 	public PostReadProcessor getPostReadProcessing(Class<?> dataType) {
-
-		PostReadProcessor processor = postReadProcessors.get(dataType);
-
-		if(processor == null) {
-			PostReadProcessor postReadProcessor = new PostReadProcessor() {
-				private final Set<PostReadProcessor> postReadProcessors =
-						plugins.stream()
-							   .map(p -> p.createPostReadProcessor(dataType))
-							   .flatMap(Optional::stream)
-							   .collect(toSet());
-
+		return postReadProcessors.computeIfAbsent(dataType, dt ->
+			new PostReadProcessor() {
+				private final Set<PostReadProcessor> postReadProcessors = plugins.stream()
+						.map(p -> p.createPostReadProcessor(dt))
+						.flatMap(Optional::stream)
+						.collect(toSet());
 				@Override
 				public DBObject postRead(DBObject postRead) {
 					for (PostReadProcessor processor : postReadProcessors) {
@@ -61,23 +56,16 @@ class Plugins {
 					}
 					return postRead;
 				}
-			};
-			postReadProcessors.put(dataType, postReadProcessor);
-			return postReadProcessor;
-		}
-		return processor;
+			});
 	}
 
 	public PreWriteProcessor getPreWriteProcessing(Class<?> dataType) {
-
-		PreWriteProcessor processor = preWriteProcessors.get(dataType);
-		if(processor == null) {
-			PreWriteProcessor preWriteProcessor = new PreWriteProcessor() {
-				private final Set<PreWriteProcessor> preWriteProcessors =
-						plugins.stream()
-							   .map(p -> p.createPreWriteProcessor(dataType))
-							   .flatMap(Optional::stream)
-							   .collect(toSet());
+		return preWriteProcessors.computeIfAbsent(dataType, dt ->
+			new PreWriteProcessor() {
+				private final Set<PreWriteProcessor> preWriteProcessors = plugins.stream()
+						.map(p -> p.createPreWriteProcessor(dataType))
+						.flatMap(Optional::stream)
+						.collect(toSet());
 
 				@Override
 				public DBObject preWrite(DBObject preWrite) {
@@ -86,10 +74,6 @@ class Plugins {
 					}
 					return preWrite;
 				}
-			};
-			preWriteProcessors.put(dataType, processor);
-			return preWriteProcessor;
-		}
-		return processor;
+			});
 	}
 }

--- a/ymer/src/main/java/com/avanza/ymer/Plugins.java
+++ b/ymer/src/main/java/com/avanza/ymer/Plugins.java
@@ -19,10 +19,10 @@ import static java.util.Collections.emptySet;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import com.avanza.ymer.plugin.Plugin;
 import com.avanza.ymer.plugin.PostReadProcessor;
@@ -31,8 +31,8 @@ import com.mongodb.DBObject;
 
 class Plugins {
 	private final Set<Plugin> plugins;
-	private final Map<Class<?>, PostReadProcessor> postReadProcessors = new ConcurrentHashMap<>();
-	private final Map<Class<?>, PreWriteProcessor> preWriteProcessors = new ConcurrentHashMap<>();
+	private final Map<Class<?>, PostReadProcessor> postReadProcessors = new HashMap<>();
+	private final Map<Class<?>, PreWriteProcessor> preWriteProcessors = new HashMap<>();
 
 	public static Plugins empty() {
 		return new Plugins(emptySet());
@@ -43,12 +43,17 @@ class Plugins {
 	}
 
 	public PostReadProcessor getPostReadProcessing(Class<?> dataType) {
-		return postReadProcessors.computeIfAbsent(dataType, dt ->
-			new PostReadProcessor() {
-				private final Set<PostReadProcessor> postReadProcessors = plugins.stream()
-						.map(p -> p.createPostReadProcessor(dt))
-						.flatMap(Optional::stream)
-						.collect(toSet());
+
+		PostReadProcessor processor = postReadProcessors.get(dataType);
+
+		if(processor == null) {
+			PostReadProcessor postReadProcessor = new PostReadProcessor() {
+				private final Set<PostReadProcessor> postReadProcessors =
+						plugins.stream()
+							   .map(p -> p.createPostReadProcessor(dataType))
+							   .flatMap(Optional::stream)
+							   .collect(toSet());
+
 				@Override
 				public DBObject postRead(DBObject postRead) {
 					for (PostReadProcessor processor : postReadProcessors) {
@@ -56,16 +61,23 @@ class Plugins {
 					}
 					return postRead;
 				}
-			});
+			};
+			postReadProcessors.put(dataType, postReadProcessor);
+			return postReadProcessor;
+		}
+		return processor;
 	}
 
 	public PreWriteProcessor getPreWriteProcessing(Class<?> dataType) {
-		return preWriteProcessors.computeIfAbsent(dataType, dt ->
-			new PreWriteProcessor() {
-				private final Set<PreWriteProcessor> preWriteProcessors = plugins.stream()
-						.map(p -> p.createPreWriteProcessor(dataType))
-						.flatMap(Optional::stream)
-						.collect(toSet());
+
+		PreWriteProcessor processor = preWriteProcessors.get(dataType);
+		if(processor == null) {
+			PreWriteProcessor preWriteProcessor = new PreWriteProcessor() {
+				private final Set<PreWriteProcessor> preWriteProcessors =
+						plugins.stream()
+							   .map(p -> p.createPreWriteProcessor(dataType))
+							   .flatMap(Optional::stream)
+							   .collect(toSet());
 
 				@Override
 				public DBObject preWrite(DBObject preWrite) {
@@ -74,6 +86,10 @@ class Plugins {
 					}
 					return preWrite;
 				}
-			});
+			};
+			preWriteProcessors.put(dataType, processor);
+			return preWriteProcessor;
+		}
+		return processor;
 	}
 }

--- a/ymer/src/test/java/com/avanza/ymer/PluginsTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/PluginsTest.java
@@ -17,13 +17,18 @@ package com.avanza.ymer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 
@@ -85,6 +90,40 @@ public class PluginsTest {
 		assertTrue(plugins.getPostReadProcessing(Object.class).postRead(BasicDBObjectBuilder.start("name", "|").get()).get("name").toString().contains("C"));
 		assertTrue(plugins.getPreWriteProcessing(Object.class).preWrite(BasicDBObjectBuilder.start("name", "|").get()).get("name").toString().contains("B"));
 		assertTrue(plugins.getPreWriteProcessing(Object.class).preWrite(BasicDBObjectBuilder.start("name", "|").get()).get("name").toString().contains("D"));
+	}
+
+	@Test
+	public void shouldPreventConcurrentModificationException() throws Exception {
+		// Arrange
+		final Plugin slowPlugin = mock(Plugin.class);
+		doAnswer(i -> {
+			Thread.sleep(10);
+			return Optional.empty();
+		}).when(slowPlugin).createPostReadProcessor(any());
+		final AtomicReference<Exception> thrownException = new AtomicReference<>();
+
+		for (int i = 0; i < 100; ++i) {
+			final Plugins plugins = new Plugins(Collections.singleton(slowPlugin));
+			final Runnable concurrentModificationOfMap = () -> {
+				try {
+					plugins.getPreWriteProcessing(this.getClass());
+				} catch (Exception e) {
+					e.printStackTrace();
+					thrownException.set(e);
+				}
+			};
+
+			// Act
+			final Thread t1 = new Thread(concurrentModificationOfMap);
+			final Thread t2 = new Thread(concurrentModificationOfMap);
+			t1.start();
+			t2.start();
+
+			// Assert
+			t1.join();
+			t2.join();
+			assertNull(thrownException.get());
+		}
 	}
 
 }


### PR DESCRIPTION
This MR contains two implementation suggestions split up into separate commits for discussion:
1) https://github.com/AvanzaBank/ymer/pull/29/commits/c4270216eb1b555104f707110c78eacf918b10b1
Simply replaces `HashMap` with `ConcurrentHashMap` to switch implementation of method `computeIfAbsent()`
2) https://github.com/AvanzaBank/ymer/pull/29/commits/627298333b128968b642a7552ae882b27bfe8188
This implementation replaces the usage of `computeIfAbsent()` with an explicit implementation instead, for the same behaviour.