### PR TITLE
TP-251: Update mongo-java-driver to 3.4.3 (gs14)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
 		<gs-test.version>14.0.3</gs-test.version>
 		<commons-logging.version>1.1.3</commons-logging.version>
 		<mongo-java-driver.version>3.4.3</mongo-java-driver.version>
-		<fongo.version>2.0.6</fongo.version>
+		<fongo.version>2.1.1</fongo.version>
 		<awaitility.version>3.0.0</awaitility.version>
 	</properties>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
 		<mockito.version>2.23.0</mockito.version>
 		<gs-test.version>14.0.3</gs-test.version>
 		<commons-logging.version>1.1.3</commons-logging.version>
-		<mongo-java-driver.version>3.2.2</mongo-java-driver.version>
+		<mongo-java-driver.version>3.4.3</mongo-java-driver.version>
 		<fongo.version>2.0.6</fongo.version>
 		<awaitility.version>3.0.0</awaitility.version>
 	</properties>

--- a/ymer/src/test/java/com/avanza/ymer/YmerFactoryTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/YmerFactoryTest.java
@@ -91,17 +91,10 @@ public class YmerFactoryTest {
 
 	private DBCollection createMockedEmptyCollection() {
 		final DBCollection collection = mock(DBCollection.class);
-		doReturn(new DBCursor(collection, new BasicDBList(), null, null) {
-			@Override
-			public boolean hasNext() {
-				return false;
-			}
-
-			@Override
-			public Spliterator<DBObject> spliterator() {
-				return Stream.<DBObject>empty().spliterator();
-			}
-		}).when(collection).find();
+		final DBCursor cursor = mock(DBCursor.class);
+		doReturn(false).when(cursor).hasNext();
+		doReturn(Stream.<DBObject>empty().spliterator()).when(cursor).spliterator();
+		doReturn(cursor).when(collection).find();
 		return collection;
 	}
 }


### PR DESCRIPTION
Same as #32 , but for gs14.

Updates:
* mongo-java-driver to 3.4.3
* fongo to 2.1.1

Does not update
* spring-data-mongodb to 1.8.6.RELEASE ( it was already at this version in this branch ).