### PR TITLE
Also accept old-style BasicDBObject in MigrationTest

### DIFF
--- a/ymer-test/src/main/java/com/avanza/ymer/YmerMigrationTestBase.java
+++ b/ymer-test/src/main/java/com/avanza/ymer/YmerMigrationTestBase.java
@@ -26,6 +26,9 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import com.mongodb.BasicDBObject;
+
 /**
  * Base class for testing that migration of documents is working properly.
  * 
@@ -136,7 +139,18 @@ public abstract class YmerMigrationTestBase {
 			this.fromVersion = oldVersion;
 			this.spaceObjectType = spaceObjectType;
 		}
-		
-	}
 
+		/**
+		 * @deprecated Please use {@link #MigrationTest(Document, Document, int, Class)} instead.
+		 */
+		@Deprecated
+		public MigrationTest(BasicDBObject oldVersionDoc, BasicDBObject expectedPatchedVersion, int oldVersion, Class<?> spaceObjectType) {
+			this(
+					new Document(oldVersionDoc),
+					new Document(expectedPatchedVersion),
+					oldVersion,
+					spaceObjectType
+			);
+		}
+	}
 }


### PR DESCRIPTION
* Updates `MigrationTest` so that it also accepts the old `BasicDBObject` types in migration unit tests.
* Reason for still allowing them is to make it easier for apps to partially migrate source to using `Document` instead.
* With this commit, an implementing app will not have to make code-changes to tests in order to compile (even making such changes would be preferable).