### PR TITLE
TP-620: Prevent using "from string" converters when writing db data

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/support/CurrencyReadConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/CurrencyReadConverter.java
@@ -16,9 +16,11 @@
 package com.avanza.ymer.support;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
 
 import java.util.Currency;
 
+@ReadingConverter
 public class CurrencyReadConverter implements Converter<String, Currency> {
 
 	@Override

--- a/ymer/src/main/java/com/avanza/ymer/support/CurrencyWriteConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/CurrencyWriteConverter.java
@@ -16,9 +16,11 @@
 package com.avanza.ymer.support;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
 
 import java.util.Currency;
 
+@WritingConverter
 public class CurrencyWriteConverter implements Converter<Currency, String> {
 
 	@Override

--- a/ymer/src/main/java/com/avanza/ymer/support/JavaInstantReadConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/JavaInstantReadConverter.java
@@ -19,7 +19,9 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
 
+@ReadingConverter
 public class JavaInstantReadConverter implements Converter<String, Instant> {
     @Override
     public Instant convert(String value) {

--- a/ymer/src/main/java/com/avanza/ymer/support/JavaInstantWriteConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/JavaInstantWriteConverter.java
@@ -19,7 +19,9 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
 
+@WritingConverter
 public class JavaInstantWriteConverter implements Converter<Instant, String> {
     @Override
     public String convert(Instant instant) {

--- a/ymer/src/main/java/com/avanza/ymer/support/JavaLocalDateReadConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/JavaLocalDateReadConverter.java
@@ -16,10 +16,12 @@
 package com.avanza.ymer.support;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+@ReadingConverter
 public class JavaLocalDateReadConverter implements Converter<String, LocalDate> {
 
 	@Override

--- a/ymer/src/main/java/com/avanza/ymer/support/JavaLocalDateTimeReadConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/JavaLocalDateTimeReadConverter.java
@@ -16,10 +16,12 @@
 package com.avanza.ymer.support;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+@ReadingConverter
 public class JavaLocalDateTimeReadConverter implements Converter<String, LocalDateTime> {
 
 	@Override

--- a/ymer/src/main/java/com/avanza/ymer/support/JavaLocalDateTimeWriteConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/JavaLocalDateTimeWriteConverter.java
@@ -16,10 +16,12 @@
 package com.avanza.ymer.support;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+@WritingConverter
 public class JavaLocalDateTimeWriteConverter implements Converter<LocalDateTime, String> {
 
 	@Override

--- a/ymer/src/main/java/com/avanza/ymer/support/JavaLocalDateWriteConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/JavaLocalDateWriteConverter.java
@@ -16,10 +16,12 @@
 package com.avanza.ymer.support;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+@WritingConverter
 public class JavaLocalDateWriteConverter implements Converter<LocalDate, String> {
 
 	@Override

--- a/ymer/src/main/java/com/avanza/ymer/support/JavaTimeLocalDateTimeReadConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/JavaTimeLocalDateTimeReadConverter.java
@@ -16,11 +16,13 @@
 package com.avanza.ymer.support;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 
+@ReadingConverter
 public class JavaTimeLocalDateTimeReadConverter implements Converter<Long, LocalDateTime> {
 
     @Override

--- a/ymer/src/main/java/com/avanza/ymer/support/JavaTimeLocalDateTimeWriteConverter.java
+++ b/ymer/src/main/java/com/avanza/ymer/support/JavaTimeLocalDateTimeWriteConverter.java
@@ -16,11 +16,13 @@
 package com.avanza.ymer.support;
 
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
+@WritingConverter
 public class JavaTimeLocalDateTimeWriteConverter implements Converter<LocalDateTime, Long> {
 
     @Override

--- a/ymer/src/test/java/com/avanza/ymer/ConverterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/ConverterTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
+import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import com.avanza.ymer.support.JavaLocalDateTimeReadConverter;
+import com.avanza.ymer.support.JavaLocalDateTimeWriteConverter;
+import com.gigaspaces.annotation.pojo.SpaceClass;
+import com.gigaspaces.annotation.pojo.SpaceId;
+import com.gigaspaces.annotation.pojo.SpaceRouting;
+import com.mongodb.BasicDBObject;
+import com.mongodb.MongoClientURI;
+
+public class ConverterTest {
+
+	private static final LocalDateTime DATE = LocalDateTime.of(1999, 12, 31, 3, 4, 5, 112);
+	private static final String DATE_STR = "1999-12-31T03:04:05.000000112";
+
+	private MappingMongoConverter converter;
+
+	@Before
+	public void beforeEachTest() {
+		final DefaultDbRefResolver ref = new DefaultDbRefResolver(
+				new SimpleMongoDbFactory(new MongoClientURI("mongodb://localhost/test"))
+		);
+		converter = new MappingMongoConverter(ref, new MongoMappingContext());
+		converter.setCustomConversions(new MongoCustomConversions(Arrays.asList(
+				new JavaLocalDateTimeReadConverter(),
+				new JavaLocalDateTimeWriteConverter()
+		)));
+		converter.afterPropertiesSet();
+	}
+
+	@Test
+	public void shouldHandleRead() {
+		// Arrange
+		BasicDBObject doc = new BasicDBObject();
+		doc.put("_id", "id_1");
+		doc.put("file", "account");
+		doc.put("time", DATE_STR);
+
+		// Act
+		ExampleSpaceObj result = converter.read(ExampleSpaceObj.class, doc);
+
+		// Assert
+		System.out.println(result);
+		assertEquals("id_1", result.getId());
+		assertEquals("account", result.getFile());
+		assertEquals(DATE, result.getTime());
+	}
+
+	@Test
+	public void shouldHandleWrite() {
+		// Arrange
+		ExampleSpaceObj obj = new ExampleSpaceObj();
+		obj.setId("id_2");
+		obj.setFile("account");
+		obj.setTime(DATE);
+
+		// Act
+		BasicDBObject doc = new BasicDBObject();
+		converter.write(obj, doc);
+
+		// Assert
+		System.out.println(doc);
+		assertEquals("id_2", doc.get("_id"));
+		assertEquals("account", doc.get("file"));
+		assertEquals(DATE_STR, doc.get("time"));
+	}
+
+	@SpaceClass
+	public static class ExampleSpaceObj {
+
+		@Id
+		private String id;
+		private String file;
+		private LocalDateTime time;
+
+		@SpaceId(autoGenerate = true)
+		public String getId() {
+			return id;
+		}
+
+		public void setId(String id) {
+			this.id = id;
+		}
+
+		@SpaceRouting
+		public String getFile() {
+			return file;
+		}
+
+		public void setFile(String file) {
+			this.file = file;
+		}
+
+		public LocalDateTime getTime() {
+			return time;
+		}
+
+		public void setTime(LocalDateTime time) {
+			this.time = time;
+		}
+
+		@Override
+		public String toString() {
+			return "SpaceFilePublicationEvent{" +
+					"id='" + id + '\'' +
+					", file='" + file + '\'' +
+					", time='" + time + '\'' +
+					'}';
+		}
+	}
+}


### PR DESCRIPTION
* Explicitly sets the type of converion expected by the ymer built-in custom converters.
* Reason for setting is to prevent that the "from string to (something)" converters are used by default when writing data to the db, such as the `LocalDateTimeReadConverter`.
* Now, instead, only the `WritingConverter`s will be used when writing data. This means that string data will not get mangled by the custom converters.
* This commit prevents exceptions such as the following:

```
2021-03-04 13:52:04,267 [GS-LRMI Connection-pool-1-thread-2] ERROR RethrowsTransientDocumentWriteExceptionHandler Exception when executing mirror command! Attempted operation: Operation: INSERT, objects: [[SpaceFilePublicationEvent{id='A1^1111111111111111^3', time=2021-03-04T13:52:02.405924, file='accounts'}]] - This command will be ignored but the rest of the commands in this bulk will be attempted. This can lead to data inconsistency in the mongo database. Must be investigated ASAP. If this error was preceeded by a TransientDocumentWriteException the cause might be that we reattempt already performed operations, which might be fine.
org.springframework.core.convert.ConversionFailedException: Failed to convert from type [java.lang.String] to type [java.time.LocalDateTime] for value 'accounts'; nested exception is java.time.format.DateTimeParseException: Text 'accounts' could not be parsed at index 0
	at org.springframework.core.convert.support.ConversionUtils.invokeConverter(ConversionUtils.java:47) ~[spring-core-5.1.7.RELEASE.jar:5.1.7.RELEASE]
	at org.springframework.core.convert.support.GenericConversionService.convert(GenericConversionService.java:191) ~[spring-core-5.1.7.RELEASE.jar:5.1.7.RELEASE]
	at org.springframework.core.convert.support.GenericConversionService.convert(GenericConversionService.java:174) ~[spring-core-5.1.7.RELEASE.jar:5.1.7.RELEASE]
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.getPotentiallyConvertedSimpleWrite(MappingMongoConverter.java:869) ~[spring-data-mongodb-2.0.14.RELEASE.jar:2.0.14.RELEASE]
	...
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.write(MappingMongoConverter.java:79) ~[spring-data-mongodb-2.0.14.RELEASE.jar:2.0.14.RELEASE]
	at com.avanza.ymer.DocumentConverter$MongoConverterDocumentConverter.convertToBsonDocument(DocumentConverter.java:132) ~[ymer-14.5.0.jar:14.5.0]
	at com.avanza.ymer.DocumentConverter.convertToBsonDocument(DocumentConverter.java:65) ~[ymer-14.5.0.jar:14.5.0]
	at com.avanza.ymer.SpaceMirrorContext.toVersionedDocument(SpaceMirrorContext.java:112) ~[ymer-14.5.0.jar:14.5.0]
	at com.avanza.ymer.MirroredObjectWriter$MongoCommand.execute(MirroredObjectWriter.java:161) [ymer-14.5.0.jar:14.5.0]
	at com.avanza.ymer.MirroredObjectWriter.insertAll(MirroredObjectWriter.java:139) [ymer-14.5.0.jar:14.5.0]
	at com.avanza.ymer.MirroredObjectWriter.executeBulk(MirroredObjectWriter.java:77) [ymer-14.5.0.jar:14.5.0]
	at com.avanza.ymer.YmerSpaceSynchronizationEndpoint.onOperationsBatchSynchronization(YmerSpaceSynchronizationEndpoint.java:44) [ymer-14.5.0.jar:14.5.0]
	at com.gigaspaces.internal.sync.mirror.MirrorBulkExecutor.execute(MirrorBulkExecutor.java:73) [xap-datagrid-14.5.0-patch-h-1.jar:?]
	at com.gigaspaces.internal.sync.mirror.MirrorReplicationInHandler.execute(MirrorReplicationInHandler.java:127) [xap-datagrid-14.5.0-patch-h-1.jar:?]
	at com.gigaspaces.internal.sync.mirror.MirrorReplicationInBatchConsumptionHandler.consumePendingOperationsInBatch(MirrorReplicationInBatchConsumptionHandler.java:44) [xap-datagrid-14.5.0-patch-h-1.jar:?]
	...
	at com.gigaspaces.lrmi.nio.Pivot$ChannelEntryTask.run(Pivot.java:173) [xap-datagrid-14.5.0-patch-h-1.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
Caused by: java.time.format.DateTimeParseException: Text 'accounts' could not be parsed at index 0
	at java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:2046) ~[?:?]
	at java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1948) ~[?:?]
	at se.avanzabank.example.persistence.mirror.LocalDateTimeReadConverter.convert(LocalDateTimeReadConverter.java:12) ~[example-pu-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
	at se.avanzabank.example.persistence.mirror.LocalDateTimeReadConverter.convert(LocalDateTimeReadConverter.java:8) ~[example-pu-0.0.1-SNAPSHOT.jar:0.0.1-SNAPSHOT]
	at org.springframework.core.convert.support.GenericConversionService$ConverterAdapter.convert(GenericConversionService.java:385) ~[spring-core-5.1.7.RELEASE.jar:5.1.7.RELEASE]
	at org.springframework.core.convert.support.ConversionUtils.invokeConverter(ConversionUtils.java:41) ~[spring-core-5.1.7.RELEASE.jar:5.1.7.RELEASE]
	... 41 more
```