### PR TITLE
TP-639: Ensure that properties are removed correctly with DocumentPatch

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/DocumentPatch.java
+++ b/ymer/src/main/java/com/avanza/ymer/DocumentPatch.java
@@ -38,7 +38,8 @@ public interface DocumentPatch extends BsonDocumentPatch {
 	default void apply(Document document) {
 		BasicDBObject dbo = new BasicDBObject(document);
 		apply(dbo);
-		document.putAll(dbo);
+		document.putAll(dbo); // Ensures that new properties are added and replaced properties are updated.
+		document.keySet().retainAll(dbo.keySet()); // Ensures that removed properties are deleted.
 	}
 
 	/**

--- a/ymer/src/test/java/com/avanza/ymer/DocumentPatchApplyTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/DocumentPatchApplyTest.java
@@ -66,7 +66,7 @@ public class DocumentPatchApplyTest {
         // Then
         assertThat(initialObject.get("theKey"), is("theValue"));
         assertThat(initialObject.get("anotherKey"), is("anotherValue"));
-        assertThat(initialObject.get("toBeRemoved"), nullValue());
+        assertThat(initialObject.get("theKeyToBeRemoved"), nullValue());
     }
 
     @Test
@@ -111,7 +111,7 @@ public class DocumentPatchApplyTest {
         // Then
         assertThat(initialObject.get("theKey"), is("theValue"));
         assertThat(initialObject.get("anotherKey"), is("anotherValue"));
-        assertThat(initialObject.get("toBeRemoved"), nullValue());
+        assertThat(initialObject.get("theKeyToBeRemoved"), nullValue());
     }
 
     @Test
@@ -155,6 +155,6 @@ public class DocumentPatchApplyTest {
         // Then
         assertThat(initialObject.get("theKey"), is("theValue"));
         assertThat(initialObject.get("anotherKey"), is("anotherValue"));
-        assertThat(initialObject.get("toBeRemoved"), nullValue());
+        assertThat(initialObject.get("theKeyToBeRemoved"), nullValue());
     }
 }

--- a/ymer/src/test/java/com/avanza/ymer/DocumentPatchApplyTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/DocumentPatchApplyTest.java
@@ -28,33 +28,8 @@ public class DocumentPatchApplyTest {
     public void shouldHandlePatchRemovalsUsingBasicDBObject() {
 
         // Given
-        DocumentPatch documentPatch$1 = new DocumentPatch() {
-
-            @Override
-            public void apply(BasicDBObject dbObject) {
-                dbObject.put("theKey", "theValue");
-                dbObject.put("theKeyToBeRemoved", "theValueToBeRemoved");
-            }
-
-            @Override
-            public int patchedVersion() {
-                return 0;
-            }
-        };
-
-        DocumentPatch documentPatch$2 = new DocumentPatch() {
-
-            @Override
-            public void apply(BasicDBObject dbObject) {
-                dbObject.put("anotherKey", "anotherValue");
-                dbObject.remove("theKeyToBeRemoved");
-            }
-
-            @Override
-            public int patchedVersion() {
-                return 1;
-            }
-        };
+        DocumentPatch documentPatch$1 = getDocumentPatch$1();
+        DocumentPatch documentPatch$2 = getDocumentPatch$2();
 
         BasicDBObject initialObject = new BasicDBObject();
 
@@ -70,41 +45,14 @@ public class DocumentPatchApplyTest {
     }
 
     @Test
-    public void shouldHandlePatchRemovalsUsingDocument() {
+    public void shouldHandlePatchRemovalsUsingDocumentOnBasicDBObject() {
 
         // Given
-        DocumentPatch documentPatch$1 = new DocumentPatch() {
-
-            @Override
-            public void apply(BasicDBObject dbObject) {
-                dbObject.put("theKey", "theValue");
-                dbObject.put("theKeyToBeRemoved", "theValueToBeRemoved");
-            }
-
-            @Override
-            public int patchedVersion() {
-                return 0;
-            }
-        };
-
-        DocumentPatch documentPatch$2 = new DocumentPatch() {
-
-            @Override
-            public void apply(BasicDBObject dbObject) {
-                dbObject.put("anotherKey", "anotherValue");
-                dbObject.remove("theKeyToBeRemoved");
-            }
-
-            @Override
-            public int patchedVersion() {
-                return 1;
-            }
-        };
-
+        DocumentPatch documentPatch$1 = getDocumentPatch$1();
+        DocumentPatch documentPatch$2 = getDocumentPatch$2();
         Document initialObject = new Document();
 
         // When
-
         documentPatch$1.apply(initialObject);
         documentPatch$2.apply(initialObject);
 
@@ -114,11 +62,8 @@ public class DocumentPatchApplyTest {
         assertThat(initialObject.get("theKeyToBeRemoved"), nullValue());
     }
 
-    @Test
-    public void shouldHandlePatchRemovalsUsingDocumentOnBasicDBOject() {
-
-        // Given
-        DocumentPatch documentPatch$1 = new DocumentPatch() {
+    private DocumentPatch getDocumentPatch$1() {
+        return new DocumentPatch() {
 
             @Override
             public void apply(BasicDBObject dbObject) {
@@ -131,8 +76,10 @@ public class DocumentPatchApplyTest {
                 return 0;
             }
         };
+    }
 
-        DocumentPatch documentPatch$2 = new DocumentPatch() {
+    private DocumentPatch getDocumentPatch$2() {
+        return new DocumentPatch() {
 
             @Override
             public void apply(BasicDBObject dbObject) {
@@ -145,16 +92,5 @@ public class DocumentPatchApplyTest {
                 return 1;
             }
         };
-        Document initialObject = new Document();
-
-        // When
-
-        documentPatch$1.apply(initialObject);
-        documentPatch$2.apply(initialObject);
-
-        // Then
-        assertThat(initialObject.get("theKey"), is("theValue"));
-        assertThat(initialObject.get("anotherKey"), is("anotherValue"));
-        assertThat(initialObject.get("theKeyToBeRemoved"), nullValue());
     }
 }

--- a/ymer/src/test/java/com/avanza/ymer/DocumentPatchApplyTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/DocumentPatchApplyTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.bson.Document;
+import org.junit.Test;
+import com.mongodb.BasicDBObject;
+
+public class DocumentPatchApplyTest {
+    @Test
+    public void shouldHandlePatchRemovalsUsingBasicDBObject() {
+
+        // Given
+        DocumentPatch documentPatch$1 = new DocumentPatch() {
+
+            @Override
+            public void apply(BasicDBObject dbObject) {
+                dbObject.put("theKey", "theValue");
+                dbObject.put("theKeyToBeRemoved", "theValueToBeRemoved");
+            }
+
+            @Override
+            public int patchedVersion() {
+                return 0;
+            }
+        };
+
+        DocumentPatch documentPatch$2 = new DocumentPatch() {
+
+            @Override
+            public void apply(BasicDBObject dbObject) {
+                dbObject.put("anotherKey", "anotherValue");
+                dbObject.remove("theKeyToBeRemoved");
+            }
+
+            @Override
+            public int patchedVersion() {
+                return 1;
+            }
+        };
+
+        BasicDBObject initialObject = new BasicDBObject();
+
+        // When
+
+        documentPatch$1.apply(initialObject);
+        documentPatch$2.apply(initialObject);
+
+        // Then
+        assertThat(initialObject.get("theKey"), is("theValue"));
+        assertThat(initialObject.get("anotherKey"), is("anotherValue"));
+        assertThat(initialObject.get("toBeRemoved"), nullValue());
+    }
+
+    @Test
+    public void shouldHandlePatchRemovalsUsingDocument() {
+
+        // Given
+        DocumentPatch documentPatch$1 = new DocumentPatch() {
+
+            @Override
+            public void apply(BasicDBObject dbObject) {
+                dbObject.put("theKey", "theValue");
+                dbObject.put("theKeyToBeRemoved", "theValueToBeRemoved");
+            }
+
+            @Override
+            public int patchedVersion() {
+                return 0;
+            }
+        };
+
+        DocumentPatch documentPatch$2 = new DocumentPatch() {
+
+            @Override
+            public void apply(BasicDBObject dbObject) {
+                dbObject.put("anotherKey", "anotherValue");
+                dbObject.remove("theKeyToBeRemoved");
+            }
+
+            @Override
+            public int patchedVersion() {
+                return 1;
+            }
+        };
+
+        Document initialObject = new Document();
+
+        // When
+
+        documentPatch$1.apply(initialObject);
+        documentPatch$2.apply(initialObject);
+
+        // Then
+        assertThat(initialObject.get("theKey"), is("theValue"));
+        assertThat(initialObject.get("anotherKey"), is("anotherValue"));
+        assertThat(initialObject.get("toBeRemoved"), nullValue());
+    }
+
+    @Test
+    public void shouldHandlePatchRemovalsUsingDocumentOnBasicDBOject() {
+
+        // Given
+        DocumentPatch documentPatch$1 = new DocumentPatch() {
+
+            @Override
+            public void apply(BasicDBObject dbObject) {
+                dbObject.put("theKey", "theValue");
+                dbObject.put("theKeyToBeRemoved", "theValueToBeRemoved");
+            }
+
+            @Override
+            public int patchedVersion() {
+                return 0;
+            }
+        };
+
+        DocumentPatch documentPatch$2 = new DocumentPatch() {
+
+            @Override
+            public void apply(BasicDBObject dbObject) {
+                dbObject.put("anotherKey", "anotherValue");
+                dbObject.remove("theKeyToBeRemoved");
+            }
+
+            @Override
+            public int patchedVersion() {
+                return 1;
+            }
+        };
+        Document initialObject = new Document();
+
+        // When
+
+        documentPatch$1.apply(initialObject);
+        documentPatch$2.apply(initialObject);
+
+        // Then
+        assertThat(initialObject.get("theKey"), is("theValue"));
+        assertThat(initialObject.get("anotherKey"), is("anotherValue"));
+        assertThat(initialObject.get("toBeRemoved"), nullValue());
+    }
+}


### PR DESCRIPTION
This PR updates `DocumentPatch` with a fix to `DocumentPatch#apply(Document)` that ensures that properties that have been removed by the applied patch are also removed in the patched `Document`.

This problem only affected projects with patches initially. based on `BasicDBObject` and are migrated to use Document in later patches.