### PR TITLE
TP-636 - Remove all Ymer compilation warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,8 @@
 	</profiles>
 
 	<properties>
-		<!-- -Xdoclint:NONE ignores validation errors in javadoc -->
-		<additionalparam>-Xdoclint:none</additionalparam>
+		<!-- -none ignores validation errors in javadoc -->
+		<doclint>none</doclint>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
 

--- a/ymer-test/src/test/java/com/avanza/ymer/YmerMigrationTestBaseTest.java
+++ b/ymer-test/src/test/java/com/avanza/ymer/YmerMigrationTestBaseTest.java
@@ -166,10 +166,11 @@ public class YmerMigrationTestBaseTest {
 		);
 
 		// Act
-		new FakeTestSuite(
+		@SuppressWarnings("deprecation")
+		var suite = new FakeTestSuite(
 				new MigrationTest(v1, expectedV2, 1, TestSpaceObject.class),
-				mirroredObjects
-		).migratesTheOldDocumentToTheNextDocumentVersion();
+				mirroredObjects);
+		suite.migratesTheOldDocumentToTheNextDocumentVersion();
 
 		// Assert that no exceptions were thrown
 	}

--- a/ymer/src/main/java/com/avanza/ymer/DocumentDb.java
+++ b/ymer/src/main/java/com/avanza/ymer/DocumentDb.java
@@ -63,6 +63,7 @@ final class DocumentDb {
 	}
 	
 	private static final class MongoDocumentDb implements DocumentDb.Provider {
+		@SuppressWarnings("deprecation")
 		private static final Set<WriteConcern> EXPECTED_WRITE_CONCERNS = new HashSet<>(Arrays.asList(WriteConcern.SAFE, WriteConcern.ACKNOWLEDGED));
 		private static final Logger LOGGER = LoggerFactory.getLogger(MongoDocumentDb.class);
 

--- a/ymer/src/test/java/com/avanza/ymer/YmerFactoryTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/YmerFactoryTest.java
@@ -43,7 +43,9 @@ import com.mongodb.client.MongoDatabase;
 
 public class YmerFactoryTest {
 	private final MongoDatabase db = mock(MongoDatabase.class);
+	@SuppressWarnings("unchecked")
 	private final MongoCollection<Document> fakeSpaceObjectCollection = createMockedEmptyCollection();
+	@SuppressWarnings("unchecked")
 	private final MongoCollection<Document> testSpaceObjectCollection = createMockedEmptyCollection();
 
 	@Before


### PR DESCRIPTION
* How to disable the javadoc warnings in the maven-javadoc-plugin was changed in v3.0.0.
* Other warnings have been suppressed.