### PR TITLE
TP-833: Fully create MongoConverter in unit tests

### DIFF
--- a/ymer-test-junit4/src/test/java/com/avanza/ymer/ExampleSpaceObjWithInstant.java
+++ b/ymer-test-junit4/src/test/java/com/avanza/ymer/ExampleSpaceObjWithInstant.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+import com.gigaspaces.annotation.pojo.SpaceClass;
+import com.gigaspaces.annotation.pojo.SpaceId;
+import com.gigaspaces.annotation.pojo.SpaceRouting;
+
+@SpaceClass
+public class ExampleSpaceObjWithInstant implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	@Id
+	private String id;
+	private Instant timestamp;
+
+	public ExampleSpaceObjWithInstant() {/*Required by GigaSpaces*/}
+
+	public ExampleSpaceObjWithInstant(String id, Instant timestamp) {
+		this.id = id;
+		this.timestamp = timestamp;
+	}
+
+	@SpaceId
+	@SpaceRouting
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public Instant getTimestamp() {
+		return timestamp;
+	}
+
+	public void setTimestamp(Instant timestamp) {
+		this.timestamp = timestamp;
+	}
+}

--- a/ymer-test-junit4/src/test/java/com/avanza/ymer/ExampleYmerConverterTest.java
+++ b/ymer-test-junit4/src/test/java/com/avanza/ymer/ExampleYmerConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.runners.Parameterized;
+import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import com.avanza.ymer.support.JavaInstantReadConverter;
+import com.avanza.ymer.support.JavaInstantWriteConverter;
+
+public class ExampleYmerConverterTest extends YmerConverterTestBase {
+
+	public ExampleYmerConverterTest(ConverterTest<?> testCase) {
+		super(testCase);
+	}
+
+	@Override
+	protected Collection<MirroredObjectDefinition<?>> getMirroredObjectDefinitions() {
+		return Collections.singletonList(
+				new MirroredObjectDefinition<>(ExampleSpaceObjWithInstant.class)
+						.loadDocumentsRouted(true)
+		);
+	}
+
+	@Override
+	protected MongoConverter createMongoConverter(MongoDbFactory mongoDbFactory) {
+		MappingMongoConverter converter = new MappingMongoConverter(
+				new DefaultDbRefResolver(mongoDbFactory),
+				new MongoMappingContext()
+		);
+		converter.setCustomConversions(new MongoCustomConversions(List.of(
+				new JavaInstantReadConverter(),
+				new JavaInstantWriteConverter()
+		)));
+		// Explicitly do NOT call "converter.afterPropertiesSet()" here
+		return converter;
+	}
+
+	@Parameterized.Parameters
+	public static List<Object[]> testCases() {
+		return buildTestCases(
+				new ConverterTest<Object>(new ExampleSpaceObjWithInstant("test", Instant.now()))
+		);
+	}
+}

--- a/ymer-test-junit4/src/test/java/com/avanza/ymer/YmerMirroredTypesTestBaseTest.java
+++ b/ymer-test-junit4/src/test/java/com/avanza/ymer/YmerMirroredTypesTestBaseTest.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singleton;
 import static org.junit.Assert.assertThrows;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.Test;
@@ -41,7 +42,10 @@ public class YmerMirroredTypesTestBaseTest {
 		YmerMirroredTypesTestBase testInstance = new YmerMirroredTypesTestBase() {
 			@Override
 			protected Collection<MirroredObjectDefinition<?>> mirroredObjectDefinitions() {
-				return singleton(new MirroredObjectDefinition<>(TestSpaceClass.class));
+				return List.of(
+						new MirroredObjectDefinition<>(TestSpaceClass.class),
+						new MirroredObjectDefinition<>(ExampleSpaceObjWithInstant.class)
+				);
 			}
 
 			@Override
@@ -58,7 +62,9 @@ public class YmerMirroredTypesTestBaseTest {
 		YmerMirroredTypesTestBase testInstance = new YmerMirroredTypesTestBase() {
 			@Override
 			protected Collection<MirroredObjectDefinition<?>> mirroredObjectDefinitions() {
-				return emptySet();
+				return List.of(
+						new MirroredObjectDefinition<>(ExampleSpaceObjWithInstant.class)
+				);
 			}
 
 			@Override
@@ -75,7 +81,9 @@ public class YmerMirroredTypesTestBaseTest {
 		YmerMirroredTypesTestBase testInstance = new YmerMirroredTypesTestBase() {
 			@Override
 			protected Collection<MirroredObjectDefinition<?>> mirroredObjectDefinitions() {
-				return emptySet();
+				return List.of(
+						new MirroredObjectDefinition<>(ExampleSpaceObjWithInstant.class)
+				);
 			}
 
 			@Override


### PR DESCRIPTION
* Makes the app-provided instance of `MongoConverter` be fully instantiated with its internal `conversionService` field when running unit tests using the converters.
* Fixes issue where, if an app provided an instance of `MongoConverter` that is not created in a spring context but only programmatically in a unit test, the tests that inherit from `YmerConverterTestBase` would not work.
* Resolves the following exception, as seen when running unit tests on an app that provides an instance of `MongoConverter` where `.afterPropertiesSet()` has not yet been called:
```
org.springframework.core.convert.ConverterNotFoundException: No converter found capable of converting from type [java.time.Instant] to type [java.lang.String]	at org.springframework.core.convert.support.GenericConversionService.handleConverterNotFound(GenericConversionService.java:321)
	at org.springframework.core.convert.support.GenericConversionService.convert(GenericConversionService.java:194)
	at org.springframework.core.convert.support.GenericConversionService.convert(GenericConversionService.java:174)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.getPotentiallyConvertedSimpleWrite(MappingMongoConverter.java:911)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.writeSimpleInternal(MappingMongoConverter.java:891)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.writeProperties(MappingMongoConverter.java:552)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.writeInternal(MappingMongoConverter.java:526)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.writeInternal(MappingMongoConverter.java:499)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.write(MappingMongoConverter.java:443)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.write(MappingMongoConverter.java:80)
	at com.avanza.ymer.DocumentConverter$MongoConverterDocumentConverter.convertToBsonDocument(DocumentConverter.java:118)
	at com.avanza.ymer.DocumentConverter.convertToBsonDocument(DocumentConverter.java:60)
	at com.avanza.ymer.TestDocumentConverter.convertToBsonDocument(TestDocumentConverter.java:37)
	at com.avanza.ymer.YmerConverterTestBase.serializationTest(YmerConverterTestBase.java:89)
org.springframework.core.convert.ConverterNotFoundException: No converter found capable of converting from type [java.time.Instant] to type [java.lang.String]	at org.springframework.core.convert.support.GenericConversionService.handleConverterNotFound(GenericConversionService.java:321)
	at org.springframework.core.convert.support.GenericConversionService.convert(GenericConversionService.java:194)
	at org.springframework.core.convert.support.GenericConversionService.convert(GenericConversionService.java:174)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.getPotentiallyConvertedSimpleWrite(MappingMongoConverter.java:911)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.writeSimpleInternal(MappingMongoConverter.java:891)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.writeProperties(MappingMongoConverter.java:552)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.writeInternal(MappingMongoConverter.java:526)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.writeInternal(MappingMongoConverter.java:499)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.write(MappingMongoConverter.java:443)
	at org.springframework.data.mongodb.core.convert.MappingMongoConverter.write(MappingMongoConverter.java:80)
	at com.avanza.ymer.DocumentConverter$MongoConverterDocumentConverter.convertToBsonDocument(DocumentConverter.java:118)
	at com.avanza.ymer.DocumentConverter.convertToBsonDocument(DocumentConverter.java:60)
	at com.avanza.ymer.TestDocumentConverter.convertToBsonDocument(TestDocumentConverter.java:37)
	at com.avanza.ymer.YmerConverterTestBase.testFailsIfSpringDataIdAnnotationNotDefinedForSpaceObject(YmerConverterTestBase.java:106)
```