### PR TITLE
TP-824: Warn when mongodb id operations do not match any documents

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/IdValidatorImpl.java
+++ b/ymer/src/main/java/com/avanza/ymer/IdValidatorImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.mongodb.DBObject;
+import com.mongodb.WriteResult;
+
+class IdValidatorImpl implements MongoDocumentCollection.IdValidator {
+	private static final Logger LOG = LoggerFactory.getLogger(MongoDocumentCollection.class);
+	private static final String ID_FIELD = "_id";
+	private final String collectionName;
+
+	IdValidatorImpl(String collectionName) {
+		this.collectionName = collectionName;
+	}
+
+	@Override
+	public void validateHasIdField(String operation, DBObject obj) {
+		if (obj.get(ID_FIELD) == null) {
+			warnAboutMissingIdField(operation);
+		}
+	}
+
+	void warnAboutMissingIdField(String operation) {
+		LOG.warn("Will {} a document on collection={} without id! "
+						+ "This is almost always an error. "
+						+ "Is the @Id field missing for objects of this type?",
+				operation,
+				collectionName
+		);
+	}
+
+	@Override
+	public void validateTouchedExistingDocument(
+			String operation,
+			WriteResult result,
+			DBObject obj
+	) {
+		if (!result.wasAcknowledged()) {
+			// No way to validate when using WriteConcern.UNACKNOWLEDGED
+			return;
+		}
+		if (didNotMatchAnyDocuments(operation, result)) {
+			warnAboutNoDocumentMatch(operation, obj.get(ID_FIELD));
+		}
+	}
+
+	private boolean didNotMatchAnyDocuments(String operation, WriteResult result) {
+		if ("update".equals(operation)) {
+			// Since "update" does ".save()", it might write a new document, which
+			// will make ".getN()" return 1. So we need to check another property here.
+			return !result.isUpdateOfExisting();
+		}
+		return result.getN() == 0;
+	}
+
+	void warnAboutNoDocumentMatch(String operation, Object id) {
+		LOG.warn("Tried to {} a document on collection={} with id={} , and no such document was found! "
+						+ "Is the @Id field missing for objects of this type?",
+				operation,
+				collectionName,
+				id
+		);
+	}
+}

--- a/ymer/src/test/java/com/avanza/ymer/IdValidatorImplTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/IdValidatorImplTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+import com.github.fakemongo.Fongo;
+import com.mongodb.BasicDBObject;
+
+public class IdValidatorImplTest {
+	private final Fongo mongoServer = new Fongo("test");
+	private final IdValidatorImpl idValidator = spy(new IdValidatorImpl("collectionName"));
+	private DocumentCollection collection;
+
+	@Before
+	public void beforeEachTest() {
+		collection = new MongoDocumentCollection(
+				mongoServer.getDB("db-name")
+						.getCollection("collectionName"),
+				idValidator
+		);
+	}
+
+	@Test
+	public void shouldNotWarnWhenHandlingObjectsWithValidIdFields() {
+		BasicDBObject obj1 = createNewObject("id1");
+		BasicDBObject obj2 = createNewObject("id2");
+
+		// Act
+		collection.insert(obj1);
+		collection.update(obj1);
+		collection.replace(obj1, obj1);
+		collection.replace(obj1, obj2);
+		collection.delete(obj2);
+
+		// Assert
+		verify(idValidator, never()).warnAboutMissingIdField(any());
+		verify(idValidator, never()).warnAboutNoDocumentMatch(any(), any());
+	}
+
+	@Test
+	public void shouldWarnAboutMissingIdFields() {
+		// Arrange
+		BasicDBObject obj = createNewObject("id1");
+
+		// Act
+		collection.insert(createNewObjectWithoutId());
+		collection.update(createNewObjectWithoutId());
+		collection.replace(obj, createNewObjectWithoutId());
+		collection.delete(createNewObjectWithoutId());
+
+		// Assert
+		verify(idValidator).warnAboutMissingIdField(eq("insert"));
+		verify(idValidator).warnAboutMissingIdField(eq("update"));
+		verify(idValidator).warnAboutMissingIdField(eq("replace"));
+		verify(idValidator).warnAboutMissingIdField(eq("delete"));
+	}
+
+	@Test
+	public void shouldWarnWhenUpdatingObjectIdThatDoesNotExist() {
+		BasicDBObject obj = createNewObject("does-not-exist");
+
+		// Act
+		collection.update(obj);
+
+		// Assert
+		verify(idValidator).warnAboutNoDocumentMatch(eq("update"), eq("does-not-exist"));
+	}
+
+	@Test
+	public void shouldWarnWhenUpdatingObjectWithoutId() {
+		BasicDBObject obj = createNewObjectWithoutId();
+
+		// Act
+		collection.update(obj);
+
+		// Assert
+		verify(idValidator).warnAboutNoDocumentMatch(eq("update"), eq(null));
+	}
+
+	@Test
+	public void shouldWarnWhenReplacingObjectIdThatDoesNotExist() {
+		BasicDBObject obj = createNewObject("does-not-exist");
+
+		// Act
+		collection.replace(obj, obj);
+
+		// Assert
+		verify(idValidator).warnAboutNoDocumentMatch(eq("replace"), eq("does-not-exist"));
+	}
+
+	@Test
+	public void shouldWarnWhenReplacingNewObjectIdThatDoesNotExist() {
+		BasicDBObject oldObj = createNewObject("does-not-exist");
+		BasicDBObject newObj = createNewObject("new-id");
+
+		// Act
+		collection.replace(oldObj, newObj);
+
+		// Assert
+		verify(idValidator).warnAboutNoDocumentMatch(eq("replace"), eq("does-not-exist"));
+	}
+
+	@Test
+	public void shouldWarnWhenDeletingObjectIdThatDoesNotExist() {
+		// Arrange
+		BasicDBObject obj = createNewObject("does-not-exist");
+
+		// Act
+		collection.delete(obj);
+
+		// Assert
+		verify(idValidator).warnAboutNoDocumentMatch(eq("delete"), eq("does-not-exist"));
+	}
+
+	private BasicDBObject createNewObject(String id) {
+		return new BasicDBObject("_id", id);
+	}
+
+	private BasicDBObject createNewObjectWithoutId() {
+		return new BasicDBObject();
+	}
+}


### PR DESCRIPTION
* Adds warning messages when writing documents to MongoDb that do not contain an `_id` field.
* Adds warning messages when MongoDb document operations (insert, update, delete) attempted to affect an existing document, but the `_id` was not found in the database.
* Reason for adding these warnings is to make it obvious for apps that there might be something misconfigured on the mirrored document types, and could lead to data loss if not addressed.
* Not having an `_id` field will auto-populate it by MongoDb when written to db, and the written value is never handled by ymer - and thus will not be replicated to the GigaSpaces space object.
* Trying to update a document for an id that does not exist likely means that the view of which documents exists differs between GigaSpaces and MongoDb.