### PR TITLE
TP-824: Warn when mongodb id operations do not match any documents

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/IdValidatorImpl.java
+++ b/ymer/src/main/java/com/avanza/ymer/IdValidatorImpl.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.mongodb.client.result.DeleteResult;
+import com.mongodb.client.result.UpdateResult;
+
+class IdValidatorImpl implements MongoDocumentCollection.IdValidator {
+	private static final Logger LOG = LoggerFactory.getLogger(MongoDocumentCollection.class);
+	private static final String ID_FIELD = "_id";
+	private final String collectionName;
+
+	IdValidatorImpl(String collectionName) {
+		this.collectionName = collectionName;
+	}
+
+	@Override
+	public void validateHasIdField(String operation, Document obj) {
+		if (obj.get(ID_FIELD) == null) {
+			warnAboutMissingIdField(operation);
+		}
+	}
+
+	void warnAboutMissingIdField(String operation) {
+		LOG.warn("Will {} a document on collection={} without id! "
+						+ "This is almost always an error. "
+						+ "Is the @Id field missing for objects of this type?",
+				operation,
+				collectionName
+		);
+	}
+
+	@Override
+	public void validateUpdatedExistingDocument(
+			String operation,
+			UpdateResult result,
+			Document obj
+	) {
+		if (!result.wasAcknowledged()) {
+			// No way to validate when using WriteConcern.UNACKNOWLEDGED
+			return;
+		}
+		if (didNotMatchAnyDocuments(result)) {
+			warnAboutNoDocumentMatch(operation, obj.get(ID_FIELD));
+		}
+	}
+
+	private boolean didNotMatchAnyDocuments(UpdateResult result) {
+		return result.getMatchedCount() == 0;
+	}
+
+	@Override
+	public void validateDeletedExistingDocument(
+			String operation,
+			DeleteResult result,
+			Document obj
+	) {
+		if (!result.wasAcknowledged()) {
+			// No way to validate when using WriteConcern.UNACKNOWLEDGED
+			return;
+		}
+		if (didNotMatchAnyDocuments(result)) {
+			warnAboutNoDocumentMatch(operation, obj.get(ID_FIELD));
+		}
+	}
+
+	private boolean didNotMatchAnyDocuments(DeleteResult result) {
+		return result.getDeletedCount() == 0;
+	}
+
+	void warnAboutNoDocumentMatch(String operation, Object id) {
+		LOG.warn("Tried to {} a document on collection={} with id={} , and no such document was found! "
+						+ "Is the @Id field missing for objects of this type?",
+				operation,
+				collectionName,
+				id
+		);
+	}
+}

--- a/ymer/src/main/java/com/avanza/ymer/IdValidatorImpl.java
+++ b/ymer/src/main/java/com/avanza/ymer/IdValidatorImpl.java
@@ -22,7 +22,7 @@ import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
 
 class IdValidatorImpl implements MongoDocumentCollection.IdValidator {
-	private static final Logger LOG = LoggerFactory.getLogger(MongoDocumentCollection.class);
+	private static final Logger LOG = LoggerFactory.getLogger(IdValidatorImpl.class);
 	private static final String ID_FIELD = "_id";
 	private final String collectionName;
 

--- a/ymer/src/test/java/com/avanza/ymer/IdValidatorImplTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/IdValidatorImplTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+
+import de.bwaldvogel.mongo.MongoServer;
+import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
+
+public class IdValidatorImplTest {
+	private final MongoServer mongoServer = new MongoServer(new MemoryBackend());
+	private final IdValidatorImpl idValidator = spy(new IdValidatorImpl("collectionName"));
+	private DocumentCollection collection;
+
+	@Before
+	public void beforeEachTest() {
+		MongoClient mongoClient = new MongoClient(new ServerAddress(mongoServer.bind()));
+		collection = new MongoDocumentCollection(
+				mongoClient.getDatabase("db-name")
+						.getCollection("collectionName"),
+				idValidator
+		);
+	}
+
+	@Test
+	public void shouldNotWarnWhenHandlingObjectsWithValidIdFields() {
+		Document obj1 = createNewObject("id1");
+		Document obj2 = createNewObject("id2");
+
+		// Act
+		collection.insert(obj1);
+		collection.update(obj1);
+		collection.replace(obj1, obj1);
+		collection.replace(obj1, obj2);
+		collection.delete(obj2);
+
+		// Assert
+		verify(idValidator, never()).warnAboutMissingIdField(any());
+		verify(idValidator, never()).warnAboutNoDocumentMatch(any(), any());
+	}
+
+	@Test
+	public void shouldWarnAboutMissingIdFields() {
+		// Arrange
+		Document obj = createNewObject("id1");
+
+		// Act
+		collection.insert(createNewObjectWithoutId());
+		collection.update(createNewObjectWithoutId());
+		collection.replace(obj, createNewObjectWithoutId());
+		collection.delete(createNewObjectWithoutId());
+
+		// Assert
+		verify(idValidator, times(2)).warnAboutMissingIdField(eq("insert"));
+		verify(idValidator).warnAboutMissingIdField(eq("update"));
+		verify(idValidator).warnAboutMissingIdField(eq("replace"));
+		verify(idValidator).warnAboutMissingIdField(eq("delete"));
+	}
+
+	@Test
+	public void shouldWarnWhenUpdatingObjectIdThatDoesNotExist() {
+		Document obj = createNewObject("does-not-exist");
+
+		// Act
+		collection.update(obj);
+
+		// Assert
+		verify(idValidator).warnAboutNoDocumentMatch(eq("update"), eq("does-not-exist"));
+	}
+
+	@Test
+	public void shouldWarnWhenUpdatingObjectWithoutId() {
+		Document obj = createNewObjectWithoutId();
+
+		// Act
+		collection.update(obj);
+
+		// Assert
+		verify(idValidator).warnAboutNoDocumentMatch(eq("update"), eq(null));
+	}
+
+	@Test
+	public void shouldWarnWhenReplacingObjectIdThatDoesNotExist() {
+		Document obj = createNewObject("does-not-exist");
+
+		// Act
+		collection.replace(obj, obj);
+
+		// Assert
+		verify(idValidator).warnAboutNoDocumentMatch(eq("replace"), eq("does-not-exist"));
+	}
+
+	@Test
+	public void shouldWarnWhenReplacingNewObjectIdThatDoesNotExist() {
+		Document oldObj = createNewObject("does-not-exist");
+		Document newObj = createNewObject("new-id");
+
+		// Act
+		collection.replace(oldObj, newObj);
+
+		// Assert
+		verify(idValidator).warnAboutNoDocumentMatch(eq("replace"), eq("does-not-exist"));
+	}
+
+	@Test
+	public void shouldWarnWhenDeletingObjectIdThatDoesNotExist() {
+		// Arrange
+		Document obj = createNewObject("does-not-exist");
+
+		// Act
+		collection.delete(obj);
+
+		// Assert
+		verify(idValidator).warnAboutNoDocumentMatch(eq("delete"), eq("does-not-exist"));
+	}
+
+	private Document createNewObject(String id) {
+		return new Document("_id", id);
+	}
+
+	private Document createNewObjectWithoutId() {
+		return new Document();
+	}
+}

--- a/ymer/src/test/java/com/avanza/ymer/YmerFactoryTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/YmerFactoryTest.java
@@ -35,6 +35,7 @@ import org.openspaces.core.cluster.ClusterInfo;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import com.avanza.ymer.MongoDocumentCollectionTest.FakeSpaceObject;
+import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
@@ -102,6 +103,7 @@ public class YmerFactoryTest {
 		doReturn(mongoCursor).when(findIterable).iterator();
 		doCallRealMethod().when(findIterable).spliterator();
 		doReturn(findIterable).when(collection).find();
+		doReturn(new MongoNamespace("test.1")).when(collection).getNamespace();
 		return collection;
 	}
 }


### PR DESCRIPTION
* Adds warning messages when writing documents to MongoDb that do not contain an `_id` field.
* Adds warning messages when MongoDb document operations (insert, update, delete) attempted to affect an existing document, but the `_id` was not found in the database.
* Reason for adding these warnings is to make it obvious for apps that there might be something misconfigured on the mirrored document types, and could lead to data loss if not addressed.
* Not having an `_id` field will auto-populate it by MongoDb when written to db, and the written value is never handled by ymer - and thus will not be replicated to the GigaSpaces space object.
* Trying to update a document for an id that does not exist likely means that the view of which documents exists differs between GigaSpaces and MongoDb.
