### PR TITLE
TP-867: Use AssertJ recursive comparison to support comparing nested objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
 		<mongo-java-driver.version>3.8.2</mongo-java-driver.version>
 		<mongo-java-server.version>1.38.0</mongo-java-server.version>
 		<awaitility.version>4.1.0</awaitility.version>
+		<assertj.version>3.21.0</assertj.version>
 
 		<!-- Maven plugins -->
 		<maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
@@ -217,6 +218,11 @@
 				<groupId>org.hamcrest</groupId>
 				<artifactId>hamcrest</artifactId>
 				<version>${hamcrest.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.assertj</groupId>
+				<artifactId>assertj-core</artifactId>
+				<version>${assertj.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>

--- a/ymer-test-junit4/pom.xml
+++ b/ymer-test-junit4/pom.xml
@@ -22,6 +22,10 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
 			<scope>test</scope>

--- a/ymer-test-junit4/src/main/java/com/avanza/ymer/YmerConverterTestBase.java
+++ b/ymer-test-junit4/src/main/java/com/avanza/ymer/YmerConverterTestBase.java
@@ -27,9 +27,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
+import org.assertj.core.matcher.AssertionMatcher;
 import org.bson.Document;
 import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -37,12 +38,12 @@ import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
 import org.springframework.data.mongodb.core.convert.AbstractMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
+
 /**
  * Base class for testing that objects may be marshalled to a mongo document and
  * then unmarshalled back into an object. <p>
  *
  * @author Elias Lindholm (elilin)
- *
  */
 @RunWith(Parameterized.class)
 public abstract class YmerConverterTestBase {
@@ -150,20 +151,25 @@ public abstract class YmerConverterTestBase {
 
 		/**
 		 * Creates a converter test that serializes and deserializes the given space-object.
-		 *
+		 * <p>
 		 * Matching for determining if deserialized object is 'correct' will be made using
-		 * Matchers.samePropertyValuesAs(spaceObject).
-		 *
+		 * AssertJ recursive comparison equals.
 		 */
 		public ConverterTest(T spaceObject) {
-			this(spaceObject, Matchers.samePropertyValuesAs(spaceObject));
+			this(spaceObject, new AssertionMatcher<>() {
+				@Override
+				public void assertion(T deserializedObject) throws AssertionError {
+					Assertions.assertThat(deserializedObject)
+							.usingRecursiveComparison()
+							.isEqualTo(spaceObject);
+				}
+			});
 		}
 
 		/**
 		 * Creates a converter test that serializes and deserializes the given space-object.
-		 *
-		 * Uses given matcher to check if deserialized version is correct. <p>
-		 *
+		 * <p>
+		 * Uses given matcher to check if deserialized version is correct.
 		 */
 		public ConverterTest(T spaceObject, Matcher<T> matcher) {
 			this.spaceObject = spaceObject;

--- a/ymer-test-junit5/pom.xml
+++ b/ymer-test-junit5/pom.xml
@@ -26,6 +26,10 @@
 			<artifactId>hamcrest</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
 			<scope>test</scope>


### PR DESCRIPTION
This adds a dependency to AsstertJ in order to support comparing nested objects.

If we want to support comparing nested objects, some kind of additional dependency is probably required.