### PR TITLE
TP-876: Speed up instance id recalculation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
 		<testcontainers.version>1.16.2</testcontainers.version>
 		<awaitility.version>4.1.0</awaitility.version>
 		<assertj.version>3.21.0</assertj.version>
+		<system-stubs.version>1.2.0</system-stubs.version>
 
 		<!-- Maven plugins -->
 		<maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
@@ -172,18 +173,10 @@
 			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-slf4j-impl</artifactId>
+				<artifactId>log4j-bom</artifactId>
 				<version>${log4j.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-core</artifactId>
-				<version>${log4j.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-1.2-api</artifactId>
-				<version>${log4j.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
 			</dependency>
 			<dependency>
 				<groupId>org.gigaspaces</groupId>
@@ -246,13 +239,11 @@
 				<groupId>com.avanza.gs</groupId>
 				<artifactId>gs-test</artifactId>
 				<version>${gs-test.version}</version>
-				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-core</artifactId>
 				<version>${log4j.version}</version>
-				<scope>test</scope>
 				<type>test-jar</type>
 			</dependency>
 			<dependency>
@@ -269,7 +260,11 @@
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
 				<version>${mockito.version}</version>
-				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>uk.org.webcompere</groupId>
+				<artifactId>system-stubs-core</artifactId>
+				<version>${system-stubs.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/ymer/pom.xml
+++ b/ymer/pom.xml
@@ -74,13 +74,8 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <scope>test</scope>
             <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -90,6 +85,12 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-core</artifactId>
+            <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
@@ -16,6 +16,9 @@
 package com.avanza.ymer;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.bson.Document;
@@ -77,9 +80,9 @@ interface DocumentCollection {
 	void update(Document document);
 
 	/**
-	 * Updates a given document, identified by id, setting only the specified fields.
+	 * Perform multiple updates in bulk
 	 */
-	void updateAllPartial(List<Document> documents);
+	void bulkUpdate(Consumer<BulkUpdater> bulkUpdater);
 
 	/**
 	 * Inserts the given object into the underlying mongo collection. <p>
@@ -98,4 +101,10 @@ interface DocumentCollection {
 	void dropIndex(String name);
 
 	void createIndex(Document keys, IndexOptions indexOptions);
+
+	interface BulkUpdater {
+
+		void updatePartialByIds(Set<Object> ids, Map<String, Object> fieldsToSet);
+
+	}
 }

--- a/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
@@ -15,7 +15,6 @@
  */
 package com.avanza.ymer;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -52,17 +51,6 @@ interface DocumentCollection {
 	Document findById(Object id);
 
 	Stream<Document> findByQuery(Query query);
-
-	/**
-	 * Find by query and a given batch size. Data will be read from the underlying
-	 * mongo collection in batches of {@code batchSize} and returned as a stream of lists,
-	 * where each list is of (at most) {@code batchSize}
-	 *
-	 * @param query the query to filter by
-	 * @param batchSize used for MongoDB cursor and the size of the lists to return
-	 * @param includeFields fields to include. If not specified, all fields will be included. The {@code _id} field is always included.
-	 */
-	Stream<List<Document>> findByQuery(Query query, int batchSize, String... includeFields);
 
 	/**
 	 * Replaces a given document in the underlying mongo collection with a new

--- a/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
@@ -50,7 +50,12 @@ interface DocumentCollection {
 
 	Stream<Document> findByQuery(Query query);
 
-	Stream<Document> findByQuery(Query query, int batchSize);
+	/**
+	 * Find by query and a given batch size. Data will be read from the underlying
+	 * mongo collection in batches of {@code batchSize} and returned as a stream of lists,
+	 * where each list is of (at most) {@code batchSize}
+	 */
+	Stream<List<Document>> findByQuery(Query query, int batchSize);
 
 	/**
 	 * Replaces a given document in the underlying mongo collection with a new

--- a/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
@@ -54,8 +54,12 @@ interface DocumentCollection {
 	 * Find by query and a given batch size. Data will be read from the underlying
 	 * mongo collection in batches of {@code batchSize} and returned as a stream of lists,
 	 * where each list is of (at most) {@code batchSize}
+	 *
+	 * @param query the query to filter by
+	 * @param batchSize used for MongoDB cursor and the size of the lists to return
+	 * @param includeFields fields to include. If not specified, all fields will be included. The {@code _id} field is always included.
 	 */
-	Stream<List<Document>> findByQuery(Query query, int batchSize);
+	Stream<List<Document>> findByQuery(Query query, int batchSize, String... includeFields);
 
 	/**
 	 * Replaces a given document in the underlying mongo collection with a new

--- a/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
@@ -15,7 +15,7 @@
  */
 package com.avanza.ymer;
 
-import java.util.Map;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.bson.Document;
@@ -50,6 +50,8 @@ interface DocumentCollection {
 
 	Stream<Document> findByQuery(Query query);
 
+	Stream<Document> findByQuery(Query query, int batchSize);
+
 	/**
 	 * Replaces a given document in the underlying mongo collection with a new
 	 * document. <p>
@@ -68,7 +70,7 @@ interface DocumentCollection {
 	/**
 	 * Updates a given document, identified by id, setting only the specified fields.
 	 */
-	void updateById(Object id, Map<String, Object> fieldsAndValuesToSet);
+	void updateAllPartial(List<Document> documents);
 
 	/**
 	 * Inserts the given object into the underlying mongo collection. <p>

--- a/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
@@ -80,9 +80,9 @@ interface DocumentCollection {
 	void update(Document document);
 
 	/**
-	 * Perform multiple updates in bulk
+	 * Perform multiple write operations in bulk
 	 */
-	void bulkUpdate(Consumer<BulkUpdater> bulkUpdater);
+	void bulkWrite(Consumer<BulkWriter> bulkWriter);
 
 	/**
 	 * Inserts the given object into the underlying mongo collection. <p>
@@ -102,7 +102,7 @@ interface DocumentCollection {
 
 	void createIndex(Document keys, IndexOptions indexOptions);
 
-	interface BulkUpdater {
+	interface BulkWriter {
 
 		void updatePartialByIds(Set<Object> ids, Map<String, Object> fieldsToSet);
 

--- a/ymer/src/main/java/com/avanza/ymer/MongoDocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/MongoDocumentCollection.java
@@ -141,9 +141,9 @@ final class MongoDocumentCollection implements DocumentCollection {
 	}
 
 	@Override
-	public void bulkUpdate(Consumer<BulkUpdater> bulkUpdater) {
+	public void bulkWrite(Consumer<BulkWriter> bulkWriter) {
 		List<WriteModel<Document>> writeModels = new ArrayList<>();
-		bulkUpdater.accept((ids, fieldsToSet) -> {
+		bulkWriter.accept((ids, fieldsToSet) -> {
 			Bson updates = toUpdates(fieldsToSet);
 			if (ids.isEmpty()) {
 				log.warn("Skipping updates because no ids provided");

--- a/ymer/src/main/java/com/avanza/ymer/MongoDocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/MongoDocumentCollection.java
@@ -31,6 +31,7 @@ import org.bson.Document;
 import org.springframework.data.mongodb.core.index.IndexInfo;
 import org.springframework.data.mongodb.core.query.Query;
 
+import com.avanza.ymer.util.StreamUtils;
 import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
@@ -95,8 +96,8 @@ final class MongoDocumentCollection implements DocumentCollection {
 	}
 
 	@Override
-	public Stream<Document> findByQuery(Query query, int batchSize) {
-		return toStream(collection.find(query.getQueryObject()).batchSize(batchSize));
+	public Stream<List<Document>> findByQuery(Query query, int batchSize) {
+		return StreamUtils.buffer(toStream(collection.find(query.getQueryObject()).batchSize(batchSize)), batchSize);
 	}
 
 	@Override

--- a/ymer/src/main/java/com/avanza/ymer/MongoDocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/MongoDocumentCollection.java
@@ -33,12 +33,14 @@ import org.springframework.data.mongodb.core.query.Query;
 
 import com.avanza.ymer.util.StreamUtils;
 import com.mongodb.MongoWriteException;
+import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.Updates;
@@ -96,8 +98,12 @@ final class MongoDocumentCollection implements DocumentCollection {
 	}
 
 	@Override
-	public Stream<List<Document>> findByQuery(Query query, int batchSize) {
-		return StreamUtils.buffer(toStream(collection.find(query.getQueryObject()).batchSize(batchSize)), batchSize);
+	public Stream<List<Document>> findByQuery(Query query, int batchSize, String... includeFields) {
+		FindIterable<Document> iterable = collection.find(query.getQueryObject()).batchSize(batchSize);
+		if(includeFields.length > 0) {
+			iterable = iterable.projection(Projections.include(includeFields));
+		}
+		return StreamUtils.buffer(toStream(iterable), batchSize);
 	}
 
 	@Override

--- a/ymer/src/main/java/com/avanza/ymer/MongoDocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/MongoDocumentCollection.java
@@ -133,6 +133,7 @@ final class MongoDocumentCollection implements DocumentCollection {
 		List<UpdateOneModel<Document>> updates = documents.stream()
 				.peek(it -> idValidator.validateHasIdField("update", it))
 				.map(this::toUpdateOneModel)
+				.filter(Objects::nonNull)
 				.collect(toList());
 		if (!updates.isEmpty()) {
 			collection.bulkWrite(updates, new BulkWriteOptions().ordered(false));

--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdRecalculationService.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdRecalculationService.java
@@ -18,6 +18,7 @@ package com.avanza.ymer;
 import static com.avanza.ymer.MirroredObject.DOCUMENT_INSTANCE_ID;
 import static com.avanza.ymer.MirroredObject.DOCUMENT_ROUTING_KEY;
 import static com.avanza.ymer.util.GigaSpacesInstanceIdUtil.getInstanceId;
+import static com.j_spaces.core.Constants.Mirror.MIRROR_SERVICE_CLUSTER_PARTITIONS_COUNT;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toSet;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
@@ -26,32 +27,62 @@ import static org.springframework.data.mongodb.core.query.Query.query;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 import org.springframework.data.mongodb.core.query.Query;
 
 import com.avanza.ymer.util.StreamUtils;
+import com.gigaspaces.internal.client.spaceproxy.IDirectSpaceProxy;
+import com.gigaspaces.internal.server.space.SpaceImpl;
+import com.j_spaces.core.IJSpace;
 import com.mongodb.client.model.IndexOptions;
 
-public class PersistedInstanceIdRecalculationService implements PersistedInstanceIdRecalculationServiceMBean {
+public class PersistedInstanceIdRecalculationService implements PersistedInstanceIdRecalculationServiceMBean, ApplicationContextAware {
+	private static final String NUMBER_OF_PARTITIONS_SYSTEM_PROPERTY = "cluster.partitions";
 	private static final int BATCH_SIZE = 10_000;
 
 	private final Logger log = LoggerFactory.getLogger(getClass());
 	private final SpaceMirrorContext spaceMirror;
+
+	@Nullable
+	private ApplicationContext applicationContext;
 
 	public PersistedInstanceIdRecalculationService(SpaceMirrorContext spaceMirror) {
 		this.spaceMirror = spaceMirror;
 	}
 
 	@Override
-	public void recalculatePersistedInstanceId(String collectionName, int numberOfInstances) {
-		log.info("Recalculating persisted instance id for collection {} with {} number of instances", collectionName, numberOfInstances);
-		String indexSuffix = "_" + numberOfInstances;
+	public void setApplicationContext(@Nonnull ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	@Override
+	public void recalculatePersistedInstanceId() {
+		int numberOfPartitions = determineNumberOfPartitions();
+
+		spaceMirror.getMirroredDocuments().stream()
+				.filter(MirroredObject::persistInstanceId)
+				.map(MirroredObject::getCollectionName)
+				.forEach(collectionName -> recalculatePersistedInstanceId(collectionName, numberOfPartitions));
+	}
+
+	private void recalculatePersistedInstanceId(String collectionName, int numberOfPartitions) {
+		log.info("Recalculating persisted instance id for collection {} with {} number of partitions", collectionName, numberOfPartitions);
+		String indexSuffix = "_" + numberOfPartitions;
 		DocumentCollection collection = spaceMirror.getDocumentDb().getCollection(collectionName);
 		boolean indexDropped = collection.getIndexes()
 				.filter(index -> index.isIndexForFields(Set.of(DOCUMENT_INSTANCE_ID)))
@@ -71,7 +102,7 @@ public class PersistedInstanceIdRecalculationService implements PersistedInstanc
 			AtomicInteger count = new AtomicInteger();
 			batches.forEach(batch -> collection.bulkWrite(bulkWriter -> {
 				Map<Integer, List<Document>> updatesByInstanceId = batch.stream()
-						.collect(groupingBy(it -> getInstanceId(it.get(DOCUMENT_ROUTING_KEY), numberOfInstances)));
+						.collect(groupingBy(it -> getInstanceId(it.get(DOCUMENT_ROUTING_KEY), numberOfPartitions)));
 
 				updatesByInstanceId.forEach((instanceId, documents) -> {
 					Set<Object> ids = documents.stream()
@@ -99,7 +130,7 @@ public class PersistedInstanceIdRecalculationService implements PersistedInstanc
 		if (indexExists) {
 			log.info("Step 3/3\tIndex does not need to be created because it already exists");
 		} else {
-			String indexName = "_index" + DOCUMENT_INSTANCE_ID + "_numberOfInstances" + indexSuffix;
+			String indexName = "_index" + DOCUMENT_INSTANCE_ID + "_numberOfPartitions" + indexSuffix;
 			log.info("Step 3/3\tCreating index {}", indexName);
 			IndexOptions options = new IndexOptions().name(indexName).background(true);
 			collection.createIndex(new Document(DOCUMENT_INSTANCE_ID, 1), options);
@@ -107,11 +138,48 @@ public class PersistedInstanceIdRecalculationService implements PersistedInstanc
 		}
 	}
 
+	private int determineNumberOfPartitions() {
+		return getNumberOfPartitionsFromSpaceProperties()
+				.or(this::getNumberOfPartitionsFromSystemProperty)
+				.orElseThrow(() -> new IllegalStateException(
+						String.format("Could not determine number of partitions, checked space property \"%s\" and system property \"%s\"",
+									  MIRROR_SERVICE_CLUSTER_PARTITIONS_COUNT, NUMBER_OF_PARTITIONS_SYSTEM_PROPERTY))
+				);
+	}
+
+	private Optional<Integer> getNumberOfPartitionsFromSpaceProperties() {
+		return Optional.ofNullable(applicationContext)
+				.map(it -> it.getBeanProvider(IJSpace.class).getIfAvailable())
+				.map(IJSpace::getDirectProxy)
+				.map(IDirectSpaceProxy::getSpaceImplIfEmbedded)
+				.map(SpaceImpl::getConfigReader)
+				.map(it -> it.getIntSpaceProperty(MIRROR_SERVICE_CLUSTER_PARTITIONS_COUNT, "0"))
+				.filter(it -> it > 0)
+				.map(peek(numberOfPartitions ->
+								  log.info("Using {} number of partitions (from space property \"{}\")", numberOfPartitions, MIRROR_SERVICE_CLUSTER_PARTITIONS_COUNT)
+				));
+	}
+
+	private Optional<Integer> getNumberOfPartitionsFromSystemProperty() {
+		return Optional.ofNullable(System.getProperty(NUMBER_OF_PARTITIONS_SYSTEM_PROPERTY))
+				.map(Integer::valueOf)
+				.map(peek(numberOfPartitions ->
+								  log.info("Using {} number of partitions (from system property \"{}\")", numberOfPartitions, NUMBER_OF_PARTITIONS_SYSTEM_PROPERTY)
+				));
+	}
+
 	@SuppressWarnings("SameParameterValue")
 	private Query createQuery(int batchSize) {
 		Query query = query(where(DOCUMENT_ROUTING_KEY).exists(true));
 		query.fields().include(DOCUMENT_ROUTING_KEY).include(DOCUMENT_INSTANCE_ID);
 		return query.cursorBatchSize(batchSize);
+	}
+
+	private static <T> UnaryOperator<T> peek(Consumer<T> consumer) {
+		return it -> {
+			consumer.accept(it);
+			return it;
+		};
 	}
 
 }

--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdRecalculationService.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdRecalculationService.java
@@ -85,7 +85,9 @@ public class PersistedInstanceIdRecalculationService implements PersistedInstanc
 								}
 							})
 							.collect(toSet());
-					bulkWriter.updatePartialByIds(ids, Map.of(DOCUMENT_INSTANCE_ID, instanceId));
+					if (!ids.isEmpty()) {
+						bulkWriter.updatePartialByIds(ids, Map.of(DOCUMENT_INSTANCE_ID, instanceId));
+					}
 				});
 			}));
 			log.info("Step 2/3\tUpdated persisted instance id for {} documents", count.get());

--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdRecalculationServiceMBean.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdRecalculationServiceMBean.java
@@ -17,6 +17,6 @@ package com.avanza.ymer;
 
 public interface PersistedInstanceIdRecalculationServiceMBean {
 
-	void recalculatePersistedInstanceId(String collectionName, int numberOfInstances);
+	void recalculatePersistedInstanceId();
 
 }

--- a/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
+++ b/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
@@ -17,15 +17,19 @@ package com.avanza.ymer;
 
 import java.lang.management.ManagementFactory;
 
+import javax.annotation.Nonnull;
 import javax.management.ObjectName;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
 
 import com.gigaspaces.sync.OperationsBatchData;
 import com.gigaspaces.sync.SpaceSynchronizationEndpoint;
 
-final class YmerSpaceSynchronizationEndpoint extends SpaceSynchronizationEndpoint {
+final class YmerSpaceSynchronizationEndpoint extends SpaceSynchronizationEndpoint implements ApplicationContextAware {
 
 	private static final Logger log = LoggerFactory.getLogger(YmerSpaceSynchronizationEndpoint.class);
 
@@ -44,6 +48,11 @@ final class YmerSpaceSynchronizationEndpoint extends SpaceSynchronizationEndpoin
 	@Override
 	public void onOperationsBatchSynchronization(OperationsBatchData batchData) {
 		mirroredObjectWriter.executeBulk(batchData);
+	}
+
+	@Override
+	public void setApplicationContext(@Nonnull ApplicationContext applicationContext) throws BeansException {
+		persistedInstanceIdRecalculationService.setApplicationContext(applicationContext);
 	}
 
 	public PersistedInstanceIdRecalculationService getPersistedInstanceIdRecalculationService() {

--- a/ymer/src/main/java/com/avanza/ymer/util/StreamUtils.java
+++ b/ymer/src/main/java/com/avanza/ymer/util/StreamUtils.java
@@ -39,18 +39,18 @@ public final class StreamUtils {
 	 */
 	public static <T> Stream<List<T>> buffer(Stream<T> source, int bufferSize) {
 		return StreamSupport.stream(() -> {
-			Spliterator<T> spliterator = source.spliterator();
-			long estimatedSize = spliterator.estimateSize();
+			Spliterator<T> sourceSpliterator = source.spliterator();
+			long estimatedSize = sourceSpliterator.estimateSize();
 			if (estimatedSize != Long.MAX_VALUE) {
-				estimatedSize = (int) Math.ceil((double) estimatedSize / (double) bufferSize);
+				estimatedSize = (long) Math.ceil(estimatedSize / (double) bufferSize);
 			}
 			return new AbstractSpliterator<List<T>>(estimatedSize, 0) {
+
 				@Override
 				public boolean tryAdvance(Consumer<? super List<T>> action) {
 					List<T> batch = new ArrayList<>(bufferSize);
-
 					for (int i = 0; i < bufferSize; i++) {
-						if (!spliterator.tryAdvance(batch::add)) {
+						if (!sourceSpliterator.tryAdvance(batch::add)) {
 							break;
 						}
 					}
@@ -61,6 +61,7 @@ public final class StreamUtils {
 						return true;
 					}
 				}
+
 			};
 		}, 0, false).onClose(source::close);
 	}

--- a/ymer/src/main/java/com/avanza/ymer/util/StreamUtils.java
+++ b/ymer/src/main/java/com/avanza/ymer/util/StreamUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.avanza.ymer.util;
 
 import java.util.ArrayList;

--- a/ymer/src/main/java/com/avanza/ymer/util/StreamUtils.java
+++ b/ymer/src/main/java/com/avanza/ymer/util/StreamUtils.java
@@ -40,8 +40,11 @@ public final class StreamUtils {
 	public static <T> Stream<List<T>> buffer(Stream<T> source, int bufferSize) {
 		return StreamSupport.stream(() -> {
 			Spliterator<T> spliterator = source.spliterator();
-			//noinspection Convert2Diamond
-			return new AbstractSpliterator<List<T>>(Long.MAX_VALUE, spliterator.characteristics()) {
+			long estimatedSize = spliterator.estimateSize();
+			if (estimatedSize != Long.MAX_VALUE) {
+				estimatedSize = (int) Math.ceil((double) estimatedSize / (double) bufferSize);
+			}
+			return new AbstractSpliterator<List<T>>(estimatedSize, 0) {
 				@Override
 				public boolean tryAdvance(Consumer<? super List<T>> action) {
 					List<T> batch = new ArrayList<>(bufferSize);
@@ -61,4 +64,5 @@ public final class StreamUtils {
 			};
 		}, 0, false).onClose(source::close);
 	}
+
 }

--- a/ymer/src/main/java/com/avanza/ymer/util/StreamUtils.java
+++ b/ymer/src/main/java/com/avanza/ymer/util/StreamUtils.java
@@ -15,16 +15,17 @@ public final class StreamUtils {
 	/**
 	 * Returns a stream with connected, non-overlapping buffers from the {@code source} stream.
 	 * The buffers will be of size {@code bufferSize} maximum, where the last one might be smaller.
-	 * The {@code source} stream will only be consumed according to the resulting stream,
-	 * i.e. if the resulting stream is limited to 2 elements, only at most {@code 2 *  bufferSize} elements will be consumed
+	 * The {@code source} stream will only be consumed according to the buffering stream,
+	 * i.e. if the buffering stream is limited to 2 elements, only at most {@code 2 *  bufferSize} elements will be consumed
 	 * from the {@code source} stream.
 	 * <p>
-	 * Note: if the resulting stream is consumed (a terminal operation is used), the {@code source} stream will also be consumed.
-	 * If the resulting stream is not consumed, the {@code source} stream will not be either.
+	 * Note: if the buffering stream is consumed (a terminal operation is used), the {@code source} stream will also be consumed.
+	 * If the buffering stream is not consumed, the {@code source} stream will not be either.
 	 */
 	public static <T> Stream<List<T>> buffer(Stream<T> source, int bufferSize) {
 		return StreamSupport.stream(() -> {
 			Spliterator<T> spliterator = source.spliterator();
+			//noinspection Convert2Diamond
 			return new AbstractSpliterator<List<T>>(Long.MAX_VALUE, spliterator.characteristics()) {
 				@Override
 				public boolean tryAdvance(Consumer<? super List<T>> action) {
@@ -43,6 +44,6 @@ public final class StreamUtils {
 					}
 				}
 			};
-		}, 0, false);
+		}, 0, false).onClose(source::close);
 	}
 }

--- a/ymer/src/main/java/com/avanza/ymer/util/StreamUtils.java
+++ b/ymer/src/main/java/com/avanza/ymer/util/StreamUtils.java
@@ -1,0 +1,48 @@
+package com.avanza.ymer.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators.AbstractSpliterator;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public final class StreamUtils {
+	private StreamUtils() {
+	}
+
+	/**
+	 * Returns a stream with connected, non-overlapping buffers from the {@code source} stream.
+	 * The buffers will be of size {@code bufferSize} maximum, where the last one might be smaller.
+	 * The {@code source} stream will only be consumed according to the resulting stream,
+	 * i.e. if the resulting stream is limited to 2 elements, only at most {@code 2 *  bufferSize} elements will be consumed
+	 * from the {@code source} stream.
+	 * <p>
+	 * Note: if the resulting stream is consumed (a terminal operation is used), the {@code source} stream will also be consumed.
+	 * If the resulting stream is not consumed, the {@code source} stream will not be either.
+	 */
+	public static <T> Stream<List<T>> buffer(Stream<T> source, int bufferSize) {
+		return StreamSupport.stream(() -> {
+			Spliterator<T> spliterator = source.spliterator();
+			return new AbstractSpliterator<List<T>>(Long.MAX_VALUE, spliterator.characteristics()) {
+				@Override
+				public boolean tryAdvance(Consumer<? super List<T>> action) {
+					List<T> batch = new ArrayList<>(bufferSize);
+
+					for (int i = 0; i < bufferSize; i++) {
+						if (!spliterator.tryAdvance(batch::add)) {
+							break;
+						}
+					}
+					if (batch.isEmpty()) {
+						return false;
+					} else {
+						action.accept(batch);
+						return true;
+					}
+				}
+			};
+		}, 0, false);
+	}
+}

--- a/ymer/src/test/java/com/avanza/ymer/DocumentCollectionContract.java
+++ b/ymer/src/test/java/com/avanza/ymer/DocumentCollectionContract.java
@@ -33,6 +33,8 @@ import static org.springframework.data.domain.Sort.Direction.ASC;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.bson.Document;
@@ -275,7 +277,7 @@ public abstract class DocumentCollectionContract {
 		document.put("first_field", "AA");
 		documentCollection.update(document);
 
-		documentCollection.updateAllPartial(List.of(new Document("_id", id).append("second_field", "BB")));
+		documentCollection.bulkUpdate(bulkUpdater -> bulkUpdater.updatePartialByIds(Set.of(id), Map.of("second_field", "BB")));
 
 		Document updatedDocument = documentCollection.findById(id);
 		assertThat(updatedDocument, hasEntry("first_field", "AA"));

--- a/ymer/src/test/java/com/avanza/ymer/DocumentCollectionContract.java
+++ b/ymer/src/test/java/com/avanza/ymer/DocumentCollectionContract.java
@@ -277,7 +277,7 @@ public abstract class DocumentCollectionContract {
 		document.put("first_field", "AA");
 		documentCollection.update(document);
 
-		documentCollection.bulkUpdate(bulkUpdater -> bulkUpdater.updatePartialByIds(Set.of(id), Map.of("second_field", "BB")));
+		documentCollection.bulkWrite(bulkWriter -> bulkWriter.updatePartialByIds(Set.of(id), Map.of("second_field", "BB")));
 
 		Document updatedDocument = documentCollection.findById(id);
 		assertThat(updatedDocument, hasEntry("first_field", "AA"));

--- a/ymer/src/test/java/com/avanza/ymer/DocumentCollectionContract.java
+++ b/ymer/src/test/java/com/avanza/ymer/DocumentCollectionContract.java
@@ -33,7 +33,6 @@ import static org.springframework.data.domain.Sort.Direction.ASC;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.bson.Document;
@@ -276,7 +275,7 @@ public abstract class DocumentCollectionContract {
 		document.put("first_field", "AA");
 		documentCollection.update(document);
 
-		documentCollection.updateById(id, Map.of("second_field", "BB"));
+		documentCollection.updateAllPartial(List.of(new Document("_id", id).append("second_field", "BB")));
 
 		Document updatedDocument = documentCollection.findById(id);
 		assertThat(updatedDocument, hasEntry("first_field", "AA"));

--- a/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
+++ b/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
@@ -22,15 +22,14 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -93,13 +92,11 @@ class FakeDocumentCollection implements DocumentCollection {
 	}
 
 	@Override
-	public void updateAllPartial(List<Document> documents) {
-		for (Document document : documents) {
-			Map<String, Object> updates = new LinkedHashMap<>(document);
-			Optional.ofNullable(updates.remove("_id"))
-					.map(this::findById)
-					.ifPresent(it -> it.putAll(updates));
-		}
+	public void bulkUpdate(Consumer<BulkUpdater> bulkUpdater) {
+		bulkUpdater.accept((ids, fieldsToSet) -> ids.stream()
+				.map(this::findById)
+				.filter(Objects::nonNull)
+				.forEach(it -> it.putAll(fieldsToSet)));
 	}
 
 	@Override

--- a/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
+++ b/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
@@ -168,11 +168,6 @@ class FakeDocumentCollection implements DocumentCollection {
 	}
 
 	@Override
-	public Stream<List<Document>> findByQuery(Query query, int batchSize, String... includeFields) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public Stream<Document> findByTemplate(Document template) {
 		throw new UnsupportedOperationException();
 	}

--- a/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
+++ b/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
@@ -22,6 +22,7 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -92,10 +93,13 @@ class FakeDocumentCollection implements DocumentCollection {
 	}
 
 	@Override
-	public void updateById(Object id, Map<String, Object> fieldsAndValuesToSet) {
-		collection.stream()
-				.filter(it -> Objects.equals(it.get("_id"), id))
-				.forEach(it -> it.putAll(fieldsAndValuesToSet));
+	public void updateAllPartial(List<Document> documents) {
+		for (Document document : documents) {
+			Map<String, Object> updates = new LinkedHashMap<>(document);
+			Optional.ofNullable(updates.remove("_id"))
+					.map(this::findById)
+					.ifPresent(it -> it.putAll(updates));
+		}
 	}
 
 	@Override
@@ -163,6 +167,11 @@ class FakeDocumentCollection implements DocumentCollection {
 
 	@Override
 	public Stream<Document> findByQuery(Query query) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Stream<Document> findByQuery(Query query, int batchSize) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
+++ b/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
@@ -171,7 +171,7 @@ class FakeDocumentCollection implements DocumentCollection {
 	}
 
 	@Override
-	public Stream<List<Document>> findByQuery(Query query, int batchSize) {
+	public Stream<List<Document>> findByQuery(Query query, int batchSize, String... includeFields) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
+++ b/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
@@ -92,8 +92,8 @@ class FakeDocumentCollection implements DocumentCollection {
 	}
 
 	@Override
-	public void bulkUpdate(Consumer<BulkUpdater> bulkUpdater) {
-		bulkUpdater.accept((ids, fieldsToSet) -> ids.stream()
+	public void bulkWrite(Consumer<BulkWriter> bulkWriter) {
+		bulkWriter.accept((ids, fieldsToSet) -> ids.stream()
 				.map(this::findById)
 				.filter(Objects::nonNull)
 				.forEach(it -> it.putAll(fieldsToSet)));

--- a/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
+++ b/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
@@ -171,7 +171,7 @@ class FakeDocumentCollection implements DocumentCollection {
 	}
 
 	@Override
-	public Stream<Document> findByQuery(Query query, int batchSize) {
+	public Stream<List<Document>> findByQuery(Query query, int batchSize) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectLoaderTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectLoaderTest.java
@@ -118,7 +118,7 @@ public class MirroredObjectLoaderTest {
 		doc4.put("spaceRouting", 2);
 		doc4.remove(DOCUMENT_INSTANCE_ID); // documents with no instance id should be loaded then filtered in java
 
-		documentCollection.createIndex(new Document(DOCUMENT_INSTANCE_ID, 1), new IndexOptions().name("_index" + DOCUMENT_INSTANCE_ID + "_numberOfInstances_" + contextProperties.getPartitionCount()));
+		documentCollection.createIndex(new Document(DOCUMENT_INSTANCE_ID, 1), new IndexOptions().name("_index" + DOCUMENT_INSTANCE_ID + "_numberOfPartitions_" + contextProperties.getPartitionCount()));
 
 		documentCollection.insertAll(doc1, doc2, doc3, doc4);
 

--- a/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
@@ -17,8 +17,8 @@ package com.avanza.ymer;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
@@ -177,13 +177,9 @@ public class MongoDocumentCollectionTest extends DocumentCollectionContract {
 
 		documentCollection.insertAll(d1, d2);
 
-		List<Document> results = documentCollection.findByQuery(query(where("count").is(21)), 10).flatMap(List::stream).collect(toList());
+		List<Document> results = documentCollection.findByQuery(query(where("count").is(21)), 10, "count").flatMap(List::stream).collect(toList());
 
-		assertThat(results, hasSize(1));
-		assertThat(results.get(0).get("_id"), is(d1.get("_id")));
-
-		assertEquals(d1, documentCollection.findById("id_1"));
-		assertEquals(d2, documentCollection.findById("id_2"));
+		assertThat(results, contains(samePropertyValuesAs(d1)));
 	}
 
 	static class FakeSpaceObject {

--- a/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
@@ -15,8 +15,14 @@
  */
 package com.avanza.ymer;
 
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.springframework.data.mongodb.core.query.Criteria.where;
+import static org.springframework.data.mongodb.core.query.Query.query;
 
 import java.util.List;
 import java.util.Objects;
@@ -155,6 +161,29 @@ public class MongoDocumentCollectionTest extends DocumentCollectionContract {
 		assertTrue(loadedSpaceObjects.toString(), loadedSpaceObjects.contains(new FakeSpaceObject(2, "b")));
 		assertTrue(loadedSpaceObjects.toString(), loadedSpaceObjects.contains(new FakeSpaceObject(4, "d")));
 		assertEquals(2, loadedSpaceObjects.size());
+	}
+
+	@Test
+	public void findByQueryAndBatchSizeReturnsExpectedDocument() {
+		MongoDocumentCollectionTest testCollection = new MongoDocumentCollectionTest();
+		DocumentCollection documentCollection = testCollection.createEmptyCollection();
+		Document d1 = new Document();
+		d1.put("_id", "id_1");
+		d1.put("count", 21);
+
+		Document d2 = new Document();
+		d2.put("_id", "id_2");
+		d2.put("count", 55);
+
+		documentCollection.insertAll(d1, d2);
+
+		List<Document> results = documentCollection.findByQuery(query(where("count").is(21))).collect(toList());
+
+		assertThat(results, hasSize(1));
+		assertThat(results.get(0).get("_id"), is(d1.get("_id")));
+
+		assertEquals(d1, documentCollection.findById("id_1"));
+		assertEquals(d2, documentCollection.findById("id_2"));
 	}
 
 	static class FakeSpaceObject {

--- a/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
@@ -177,7 +177,7 @@ public class MongoDocumentCollectionTest extends DocumentCollectionContract {
 
 		documentCollection.insertAll(d1, d2);
 
-		List<Document> results = documentCollection.findByQuery(query(where("count").is(21))).collect(toList());
+		List<Document> results = documentCollection.findByQuery(query(where("count").is(21)), 10).flatMap(List::stream).collect(toList());
 
 		assertThat(results, hasSize(1));
 		assertThat(results.get(0).get("_id"), is(d1.get("_id")));

--- a/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
@@ -177,7 +177,10 @@ public class MongoDocumentCollectionTest extends DocumentCollectionContract {
 
 		documentCollection.insertAll(d1, d2);
 
-		List<Document> results = documentCollection.findByQuery(query(where("count").is(21)), 10, "count").flatMap(List::stream).collect(toList());
+		Query query = query(where("count").is(21)).cursorBatchSize(10);
+		query.fields().include("count");
+
+		List<Document> results = documentCollection.findByQuery(query).collect(toList());
 
 		assertThat(results, contains(samePropertyValuesAs(d1)));
 	}

--- a/ymer/src/test/java/com/avanza/ymer/PersistedInstanceIdRecalculationServiceTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/PersistedInstanceIdRecalculationServiceTest.java
@@ -38,7 +38,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.springframework.context.ApplicationContext;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.data.mongodb.core.index.IndexInfo;
 
 import com.avanza.gs.test.PuConfigurers;
@@ -87,10 +87,11 @@ public class PersistedInstanceIdRecalculationServiceTest {
 				.configure()) {
 			mirrorPu.start();
 
-			ApplicationContext applicationContext = (ApplicationContext) mirrorPu.getApplicationContexts().iterator().next();
-			target.setApplicationContext(applicationContext);
+			BeanFactory applicationContext = mirrorPu.getApplicationContexts().iterator().next();
+			YmerSpaceSynchronizationEndpoint spaceSynchronizationEndpoint = applicationContext.getBean(YmerSpaceSynchronizationEndpoint.class);
+			PersistedInstanceIdRecalculationService persistedInstanceIdRecalculationService = spaceSynchronizationEndpoint.getPersistedInstanceIdRecalculationService();
 
-			target.recalculatePersistedInstanceId();
+			persistedInstanceIdRecalculationService.recalculatePersistedInstanceId();
 
 			verifyCollection(numberOfInstances);
 		}

--- a/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
+++ b/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
@@ -25,6 +25,8 @@ public class TestSpaceMirrorObjectDefinitions  {
 
 	public static final MirroredObjectDefinition<TestSpaceObject> TEST_SPACE_OBJECT =
 			MirroredObjectDefinition.create(TestSpaceObject.class)
+					.loadDocumentsRouted(true)
+					.persistInstanceId(true)
 					.documentPatches(new TestSpaceObjectV1Patch(), new TestSpaceObjectV2Patch());
 
 	public static final MirroredObjectDefinition<TestSpaceOtherObject> TEST_SPACE_OTHER_OBJECT =

--- a/ymer/src/test/java/com/avanza/ymer/util/StreamUtilsTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/util/StreamUtilsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.avanza.ymer.util;
 
 import static java.util.Collections.emptyList;

--- a/ymer/src/test/java/com/avanza/ymer/util/StreamUtilsTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/util/StreamUtilsTest.java
@@ -1,0 +1,77 @@
+package com.avanza.ymer.util;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+public class StreamUtilsTest {
+
+	@Test
+	public void shouldReturnAllElementsInBatches() {
+		LongAdder numberOfBatches = new LongAdder();
+		List<Integer> totalResults = new LinkedList<>();
+
+		StreamUtils.buffer(IntStream.rangeClosed(1, 33).boxed(), 10)
+				.peek(ignore -> numberOfBatches.increment())
+				.forEach(totalResults::addAll);
+
+		assertThat(numberOfBatches.intValue(), is(4));
+		assertThat(totalResults, is(IntStream.rangeClosed(1, 33).boxed().collect(toList())));
+	}
+
+	@Test
+	public void shouldReturnFirstTwoBatches() {
+		LongAdder numberOfBatches = new LongAdder();
+		List<Integer> totalResults = new LinkedList<>();
+
+		StreamUtils.buffer(IntStream.rangeClosed(1, 33).boxed(), 10)
+				.limit(2)
+				.peek(ignore -> numberOfBatches.increment())
+				.forEach(totalResults::addAll);
+
+		assertThat(numberOfBatches.intValue(), is(2));
+		assertThat(totalResults, is(IntStream.rangeClosed(1, 20).boxed().collect(toList())));
+	}
+
+	@Test
+	public void shouldReturnEmptyStream() {
+		LongAdder numberOfBatches = new LongAdder();
+		List<Integer> totalResults = new LinkedList<>();
+
+		StreamUtils.buffer(Stream.<Integer>empty(), 10)
+				.peek(ignore -> numberOfBatches.increment())
+				.forEach(totalResults::addAll);
+
+		assertThat(numberOfBatches.intValue(), is(0));
+		assertThat(totalResults, is(emptyList()));
+	}
+
+	@Test
+	public void shouldConsumeSourceStreamOnTerminalOperation() {
+		Stream<Integer> source = Stream.of(1);
+
+		StreamUtils.buffer(source, 10).forEach(it -> {});
+
+		assertThrows("Stream should already be consumed", IllegalStateException.class, () -> source.forEach(it -> {}));
+	}
+
+	@Test
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	public void shouldNotConsumeSourceStreamOnNoTerminalOperation() {
+		Stream<Integer> source = Stream.of(1);
+
+		StreamUtils.buffer(source, 10).map(List::size);
+
+		source.forEach(it -> {});
+	}
+}

--- a/ymer/src/test/java/com/avanza/ymer/util/StreamUtilsTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/util/StreamUtilsTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertThrows;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -73,5 +74,17 @@ public class StreamUtilsTest {
 		StreamUtils.buffer(source, 10).map(List::size);
 
 		source.forEach(it -> {});
+	}
+
+	@Test
+	public void closingBufferedStreamShouldCloseSourceStream() {
+		AtomicBoolean sourceClosed = new AtomicBoolean(false);
+		Stream<Integer> source = Stream.of(1).onClose(() -> sourceClosed.set(true));
+
+		Stream<List<Integer>> bufferingStream = StreamUtils.buffer(source, 1);
+
+		bufferingStream.close();
+
+		assertThat(sourceClosed.get(), is(true));
 	}
 }


### PR DESCRIPTION
Update documents in batches, to reduce overhead. Use the same batch size for reading documents to update.