### PR TITLE
TP-828: Trigger recalculation of persisted instance IDs on startup

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
@@ -16,6 +16,7 @@
 package com.avanza.ymer;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 
 import javax.annotation.Nullable;
 
@@ -43,7 +44,7 @@ final class MirroredObject<T> {
 	private final boolean loadDocumentsRouted;
 	private final boolean persistInstanceId;
 	private final boolean recalculateInstanceIdOnStartup;
-	private final int recalculateInstanceIdWithDelay;
+	private final Duration recalculateInstanceIdWithDelay;
 	private final boolean keepPersistent;
     private final String collectionName;
 	private final TemplateFactory customInitialLoadTemplateFactory;
@@ -218,7 +219,7 @@ final class MirroredObject<T> {
 		return recalculateInstanceIdOnStartup;
 	}
 
-	int recalculateInstanceIdWithDelay() {
+	Duration recalculateInstanceIdWithDelay() {
 		return recalculateInstanceIdWithDelay;
 	}
 

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
@@ -42,6 +42,8 @@ final class MirroredObject<T> {
 	private final boolean writeBackPatchedDocuments;
 	private final boolean loadDocumentsRouted;
 	private final boolean persistInstanceId;
+	private final boolean recalculateInstanceIdOnStartup;
+	private final int recalculateInstanceIdWithDelay;
 	private final boolean keepPersistent;
     private final String collectionName;
 	private final TemplateFactory customInitialLoadTemplateFactory;
@@ -53,7 +55,12 @@ final class MirroredObject<T> {
 		this.excludeFromInitialLoad = override.excludeFromInitialLoad(definition);
         this.writeBackPatchedDocuments = override.writeBackPatchedDocuments(definition);
         this.loadDocumentsRouted = override.loadDocumentsRouted(definition);
-        this.persistInstanceId = override.persistInstanceId(definition);
+
+		PersistInstanceIdDefinition<?> persistInstanceId = override.persistInstanceId(definition);
+        this.persistInstanceId = persistInstanceId.isEnabled();
+		this.recalculateInstanceIdOnStartup = persistInstanceId.isRecalculateOnStartup();
+		this.recalculateInstanceIdWithDelay = persistInstanceId.getRecalculateWithDelay();
+
         this.keepPersistent = definition.keepPersistent();
         this.collectionName = definition.collectionName();
         this.customInitialLoadTemplateFactory = definition.customInitialLoadTemplateFactory();
@@ -205,6 +212,14 @@ final class MirroredObject<T> {
 
 	boolean persistInstanceId() {
 		return persistInstanceId;
+	}
+
+	boolean recalculateInstanceIdOnStartup() {
+		return recalculateInstanceIdOnStartup;
+	}
+
+	int recalculateInstanceIdWithDelay() {
+		return recalculateInstanceIdWithDelay;
 	}
 
 	ReadPreference getReadPreference() {

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinition.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinition.java
@@ -52,7 +52,7 @@ public final class MirroredObjectDefinition<T> {
 	private boolean excludeFromInitialLoad = false;
 	private boolean writeBackPatchedDocuments = true;
 	private boolean loadDocumentsRouted = false;
-	private boolean persistInstanceId = false;
+	private final PersistInstanceIdDefinition<T> persistInstanceId = new PersistInstanceIdDefinition<>(this);
 	private boolean keepPersistent = false;
 	private TemplateFactory customInitialLoadTemplateFactory;
 	private ReadPreference readPreference;
@@ -148,13 +148,14 @@ public final class MirroredObjectDefinition<T> {
 	 * Whether to persist the current instance id for each document.
 	 * This can increase load speed, but requires all persisted partition numbers to be recalculated
 	 * when the number of partitions change.
+	 *
+	 * This will enable persisting of instance id with default settings.
 	 */
-	public MirroredObjectDefinition<T> persistInstanceId(boolean persistInstanceId) {
-		this.persistInstanceId = persistInstanceId;
-		return this;
+	public PersistInstanceIdDefinition<T> persistInstanceId() {
+		return persistInstanceId.enableWithDefaults();
 	}
 
-	boolean persistInstanceId() {
+	PersistInstanceIdDefinition<T> getPersistInstanceId() {
 		return persistInstanceId;
 	}
 

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinitionsOverride.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinitionsOverride.java
@@ -15,6 +15,7 @@
  */
 package com.avanza.ymer;
 
+import java.time.Duration;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -83,7 +84,9 @@ public interface MirroredObjectDefinitionsOverride {
             PersistInstanceIdDefinition<?> persistInstanceId = PersistInstanceIdDefinition.from(definition.getPersistInstanceId());
             getProperty(definition, "persistInstanceId").ifPresent(persistInstanceId::enabled);
             getProperty(definition, "recalculateInstanceIdOnStartup").ifPresent(persistInstanceId::recalculateOnStartup);
-            getIntProperty(definition, "recalculateInstanceIdWithDelay").ifPresent(persistInstanceId::recalculateWithDelay);
+            getIntProperty(definition, "recalculateInstanceIdWithDelay")
+                    .map(Duration::ofSeconds)
+                    .ifPresent(persistInstanceId::recalculateWithDelay);
             return persistInstanceId;
         }
 

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinitionsOverride.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinitionsOverride.java
@@ -17,12 +17,17 @@ package com.avanza.ymer;
 
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public interface MirroredObjectDefinitionsOverride {
+
+    Logger log = LoggerFactory.getLogger(MirroredObjectDefinitionsOverride.class);
 
     boolean excludeFromInitialLoad(MirroredObjectDefinition<?> definition);
     boolean writeBackPatchedDocuments(MirroredObjectDefinition<?> definition);
     boolean loadDocumentsRouted(MirroredObjectDefinition<?> definition);
-    boolean persistInstanceId(MirroredObjectDefinition<?> definition);
+    PersistInstanceIdDefinition<?> persistInstanceId(MirroredObjectDefinition<?> definition);
 
     static MirroredObjectDefinitionsOverride noOverride() {
         return new MirroredObjectDefinitionsOverrideNone();
@@ -49,8 +54,8 @@ public interface MirroredObjectDefinitionsOverride {
         }
 
         @Override
-        public boolean persistInstanceId(MirroredObjectDefinition<?> definition) {
-            return definition.persistInstanceId();
+        public PersistInstanceIdDefinition<?> persistInstanceId(MirroredObjectDefinition<?> definition) {
+            return definition.getPersistInstanceId();
         }
     }
 
@@ -74,15 +79,30 @@ public interface MirroredObjectDefinitionsOverride {
         }
 
         @Override
-        public boolean persistInstanceId(MirroredObjectDefinition<?> definition) {
-            return getProperty(definition, "persistInstanceId")
-                    .orElse(definition.persistInstanceId());
+        public PersistInstanceIdDefinition<?> persistInstanceId(MirroredObjectDefinition<?> definition) {
+            PersistInstanceIdDefinition<?> persistInstanceId = PersistInstanceIdDefinition.from(definition.getPersistInstanceId());
+            getProperty(definition, "persistInstanceId").ifPresent(persistInstanceId::enabled);
+            getProperty(definition, "recalculateInstanceIdOnStartup").ifPresent(persistInstanceId::recalculateOnStartup);
+            getIntProperty(definition, "recalculateInstanceIdWithDelay").ifPresent(persistInstanceId::recalculateWithDelay);
+            return persistInstanceId;
         }
 
         private Optional<Boolean> getProperty(MirroredObjectDefinition<?> definition, String setting) {
             return Optional.ofNullable(System.getProperty(getPropertyName(definition, setting)))
                     .filter(s -> s.equals("true") || s.equals("false"))
                     .map("true"::equals);
+        }
+
+        private Optional<Integer> getIntProperty(MirroredObjectDefinition<?> definition, String setting) {
+            return Optional.ofNullable(System.getProperty(getPropertyName(definition, setting)))
+                    .flatMap(s -> {
+                        try {
+                            return Optional.of(Integer.valueOf(s));
+                        } catch (NumberFormatException e) {
+                            log.warn("Could not parse setting {} with value [{}] as int", setting, s);
+                            return Optional.empty();
+                        }
+                    });
         }
 
         public static String getPropertyName(MirroredObjectDefinition<?> definition, String setting) {

--- a/ymer/src/main/java/com/avanza/ymer/PersistInstanceIdDefinition.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistInstanceIdDefinition.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+o * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+public final class PersistInstanceIdDefinition<T> {
+
+	private static final int DEFAULT_DELAY = 60 * 60;
+
+	private final MirroredObjectDefinition<T> parent;
+	private boolean enabled;
+	private boolean recalculateOnStartup;
+	private int recalculateWithDelay = DEFAULT_DELAY;
+
+	PersistInstanceIdDefinition(MirroredObjectDefinition<T> parent) {
+		this.parent = parent;
+	}
+
+	static <T> PersistInstanceIdDefinition<T> from(PersistInstanceIdDefinition<T> from) {
+		return new PersistInstanceIdDefinition<>(from.getParent())
+				.enabled(from.enabled)
+				.recalculateOnStartup(from.recalculateOnStartup)
+				.recalculateWithDelay(from.recalculateWithDelay);
+	}
+
+	public PersistInstanceIdDefinition<T> enableWithDefaults() {
+		return enabled(true).recalculateOnStartup(true);
+	}
+
+	/**
+	 * Whether to enable persisting the instance id for each document.
+	 */
+	public PersistInstanceIdDefinition<T> enabled(boolean enabled) {
+		this.enabled = enabled;
+		return this;
+	}
+
+	/**
+	 * Whether to recalculate persisted instance id on startup if necessary.
+	 * If enabled, instance id will be recalculated on startup (with a delay configured by
+	 * {@code delayRecalculationOnStartupWithSeconds}).
+	 * If disabled, instance id will only be recalculated when manually called.
+	 * This defaults to {@code true} when persisting instance id is enabled.
+	 *
+	 * Automatically starting this job requires {@link YmerSpaceSynchronizationEndpoint} to be handled
+	 * as a Spring bean.
+	 */
+	public PersistInstanceIdDefinition<T> recalculateOnStartup(boolean recalculateOnStartup) {
+		this.recalculateOnStartup = recalculateOnStartup;
+		return this;
+	}
+
+	/**
+	 * Delay starting recalculation of persisted instance id with the specified delay after startup (in seconds).
+	 * This is done do reduce load on database during initial load of data.
+	 */
+	public PersistInstanceIdDefinition<T> recalculateWithDelay(int recalculateOnStartupDelayInSeconds) {
+		this.recalculateWithDelay = recalculateOnStartupDelayInSeconds;
+		return this;
+	}
+
+	/**
+	 * Return the MirroredObjectDefinition when done configuring the PersistInstanceIdDefinition.
+	 * This is useful for method chaining.
+	 *
+	 * @return the MirroredObjectDefinition for further customizations
+	 */
+	public MirroredObjectDefinition<T> and() {
+		return getParent();
+	}
+
+	private MirroredObjectDefinition<T> getParent() {
+		return parent;
+	}
+
+	boolean isEnabled() {
+		return enabled;
+	}
+
+	boolean isRecalculateOnStartup() {
+		return recalculateOnStartup;
+	}
+
+	int getRecalculateWithDelay() {
+		return recalculateWithDelay;
+	}
+}

--- a/ymer/src/main/java/com/avanza/ymer/PersistInstanceIdDefinition.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistInstanceIdDefinition.java
@@ -15,14 +15,16 @@
  */
 package com.avanza.ymer;
 
+import java.time.Duration;
+
 public final class PersistInstanceIdDefinition<T> {
 
-	private static final int DEFAULT_DELAY = 60 * 60;
+	private static final Duration DEFAULT_DELAY = Duration.ofHours(1);
 
 	private final MirroredObjectDefinition<T> parent;
 	private boolean enabled;
 	private boolean recalculateOnStartup;
-	private int recalculateWithDelay = DEFAULT_DELAY;
+	private Duration recalculateWithDelay = DEFAULT_DELAY;
 
 	PersistInstanceIdDefinition(MirroredObjectDefinition<T> parent) {
 		this.parent = parent;
@@ -63,11 +65,11 @@ public final class PersistInstanceIdDefinition<T> {
 	}
 
 	/**
-	 * Delay starting recalculation of persisted instance id with the specified delay after startup (in seconds).
+	 * Delay starting recalculation of persisted instance id with the specified delay after startup.
 	 * This is done to reduce load on database during initial load of data.
 	 */
-	public PersistInstanceIdDefinition<T> recalculateWithDelay(int recalculateOnStartupDelayInSeconds) {
-		this.recalculateWithDelay = recalculateOnStartupDelayInSeconds;
+	public PersistInstanceIdDefinition<T> recalculateWithDelay(Duration recalculateOnStartupDelay) {
+		this.recalculateWithDelay = recalculateOnStartupDelay;
 		return this;
 	}
 
@@ -93,7 +95,7 @@ public final class PersistInstanceIdDefinition<T> {
 		return recalculateOnStartup;
 	}
 
-	int getRecalculateWithDelay() {
+	Duration getRecalculateWithDelay() {
 		return recalculateWithDelay;
 	}
 }

--- a/ymer/src/main/java/com/avanza/ymer/PersistInstanceIdDefinition.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistInstanceIdDefinition.java
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
-o * Copyright 2015 Avanza Bank AB
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.avanza.ymer;
 
 public final class PersistInstanceIdDefinition<T> {
@@ -79,7 +64,7 @@ public final class PersistInstanceIdDefinition<T> {
 
 	/**
 	 * Delay starting recalculation of persisted instance id with the specified delay after startup (in seconds).
-	 * This is done do reduce load on database during initial load of data.
+	 * This is done to reduce load on database during initial load of data.
 	 */
 	public PersistInstanceIdDefinition<T> recalculateWithDelay(int recalculateOnStartupDelayInSeconds) {
 		this.recalculateWithDelay = recalculateOnStartupDelayInSeconds;

--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdRecalculationService.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdRecalculationService.java
@@ -19,6 +19,7 @@ import static com.avanza.ymer.MirroredObject.DOCUMENT_INSTANCE_ID;
 import static com.avanza.ymer.MirroredObject.DOCUMENT_ROUTING_KEY;
 import static com.avanza.ymer.util.GigaSpacesInstanceIdUtil.getInstanceId;
 import static com.j_spaces.core.Constants.Mirror.MIRROR_SERVICE_CLUSTER_PARTITIONS_COUNT;
+import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toSet;
 import static org.springframework.data.mongodb.core.query.Criteria.where;
@@ -32,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
@@ -44,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.data.mongodb.core.index.IndexInfo;
 import org.springframework.data.mongodb.core.query.Query;
 
 import com.avanza.ymer.util.StreamUtils;
@@ -71,6 +74,19 @@ public class PersistedInstanceIdRecalculationService implements PersistedInstanc
 		this.applicationContext = applicationContext;
 	}
 
+	public boolean collectionNeedsCalculation(String collectionName) {
+		try {
+			int numberOfPartitions = determineNumberOfPartitions();
+			DocumentCollection collection = spaceMirror.getDocumentDb().getCollection(collectionName);
+			return collection.getIndexes()
+					.filter(index -> index.isIndexForFields(Set.of(DOCUMENT_INSTANCE_ID)))
+					.noneMatch(isIndexForNumberOfPartitions(numberOfPartitions));
+		} catch (Exception e) {
+			log.warn("Could not determine whether persisted instance id should be recalculated for collection " + collectionName, e);
+			return false;
+		}
+	}
+
 	@Override
 	public void recalculatePersistedInstanceId() {
 		int numberOfPartitions = determineNumberOfPartitions();
@@ -81,13 +97,18 @@ public class PersistedInstanceIdRecalculationService implements PersistedInstanc
 				.forEach(collectionName -> recalculatePersistedInstanceId(collectionName, numberOfPartitions));
 	}
 
+	@Override
+	public void recalculatePersistedInstanceId(String collectionName) {
+		int numberOfPartitions = determineNumberOfPartitions();
+		recalculatePersistedInstanceId(collectionName, numberOfPartitions);
+	}
+
 	private void recalculatePersistedInstanceId(String collectionName, int numberOfPartitions) {
 		log.info("Recalculating persisted instance id for collection {} with {} number of partitions", collectionName, numberOfPartitions);
-		String indexSuffix = "_" + numberOfPartitions;
 		DocumentCollection collection = spaceMirror.getDocumentDb().getCollection(collectionName);
 		boolean indexDropped = collection.getIndexes()
 				.filter(index -> index.isIndexForFields(Set.of(DOCUMENT_INSTANCE_ID)))
-				.filter(index -> !index.getName().endsWith(indexSuffix))
+				.filter(not(isIndexForNumberOfPartitions(numberOfPartitions)))
 				.peek(index -> {
 					log.info("Step 1/3\tDropping index {}", index.getName());
 					collection.dropIndex(index.getName());
@@ -129,16 +150,21 @@ public class PersistedInstanceIdRecalculationService implements PersistedInstanc
 
 		boolean indexExists = collection.getIndexes()
 				.filter(index -> index.isIndexForFields(Set.of(DOCUMENT_INSTANCE_ID)))
-				.anyMatch(index -> index.getName().endsWith(indexSuffix));
+				.anyMatch(isIndexForNumberOfPartitions(numberOfPartitions));
 		if (indexExists) {
 			log.info("Step 3/3\tIndex does not need to be created because it already exists");
 		} else {
-			String indexName = "_index" + DOCUMENT_INSTANCE_ID + "_numberOfPartitions" + indexSuffix;
+			String indexName = "_index" + DOCUMENT_INSTANCE_ID + "_numberOfPartitions_" + numberOfPartitions;
 			log.info("Step 3/3\tCreating index {}", indexName);
 			IndexOptions options = new IndexOptions().name(indexName).background(true);
 			collection.createIndex(new Document(DOCUMENT_INSTANCE_ID, 1), options);
 			log.info("Step 3/3\tDone creating index");
 		}
+	}
+
+	private Predicate<IndexInfo> isIndexForNumberOfPartitions(int numberOfPartitions) {
+		String indexSuffix = "_numberOfPartitions_" + numberOfPartitions;
+		return index -> index.getName().endsWith(indexSuffix);
 	}
 
 	private int determineNumberOfPartitions() {

--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdRecalculationServiceMBean.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdRecalculationServiceMBean.java
@@ -19,4 +19,6 @@ public interface PersistedInstanceIdRecalculationServiceMBean {
 
 	void recalculatePersistedInstanceId();
 
+	void recalculatePersistedInstanceId(String collectionName);
+
 }

--- a/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
+++ b/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
@@ -18,6 +18,7 @@ package com.avanza.ymer;
 import static java.util.stream.Collectors.toList;
 
 import java.lang.management.ManagementFactory;
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -90,12 +91,13 @@ final class YmerSpaceSynchronizationEndpoint extends SpaceSynchronizationEndpoin
 				.collect(toList());
 
 		for (MirroredObject<?> mirroredObject : objectsToRecalculate) {
-			log.info("Will trigger recalculation of persisted instance id for collections [{}] starting in {} seconds",
+			Duration startJobIn = mirroredObject.recalculateInstanceIdWithDelay();
+			log.info("Will trigger recalculation of persisted instance id for collections [{}] starting in {}",
 					objectsToRecalculate.stream().map(MirroredObject::getCollectionName).collect(Collectors.joining(",")),
-					mirroredObject.recalculateInstanceIdWithDelay()
+					startJobIn
 			);
 			Runnable task = () -> persistedInstanceIdRecalculationService.recalculatePersistedInstanceId(mirroredObject.getCollectionName());
-			scheduledExecutorService.schedule(task, mirroredObject.recalculateInstanceIdWithDelay(), TimeUnit.SECONDS);
+			scheduledExecutorService.schedule(task, startJobIn.getSeconds(), TimeUnit.SECONDS);
 		}
 	}
 

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectLoaderTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectLoaderTest.java
@@ -95,7 +95,8 @@ public class MirroredObjectLoaderTest {
 	@Test
 	public void loadsAllObjectsRoutedToCurrentPartitionByPersistedInstanceId() {
 		MirroredObject<FakeSpaceObject> mirroredObject = MirroredObjectDefinition.create(FakeSpaceObject.class)
-				.persistInstanceId(true)
+				.persistInstanceId()
+				.and()
 				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 
 		Document doc1 = new Document();

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectTest.java
@@ -342,7 +342,8 @@ public class MirroredObjectTest {
 	@Test
 	public void setsInstanceIdAndRoutingKeyForPersistInstanceId() throws Exception {
 		MirroredObject<MirroredType> document = MirroredObjectDefinition.create(MirroredType.class)
-				.persistInstanceId(true)
+				.persistInstanceId()
+				.and()
 				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 		Document dbObject = new Document();
 
@@ -356,7 +357,8 @@ public class MirroredObjectTest {
 	@Test
 	public void doesNotSetInstanceIdWhenNull() throws Exception {
 		MirroredObject<MirroredType> document = MirroredObjectDefinition.create(MirroredType.class)
-				.persistInstanceId(true)
+				.persistInstanceId()
+				.and()
 				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 		Document dbObject = new Document();
 
@@ -371,8 +373,9 @@ public class MirroredObjectTest {
 		MirroredObjectDefinition<RoutedType> definition = MirroredObjectDefinition.create(RoutedType.class)
 				.loadDocumentsRouted(true)
 				.writeBackPatchedDocuments(true)
-				.excludeFromInitialLoad(true)
-				.persistInstanceId(true);
+				.persistInstanceId()
+				.and()
+				.excludeFromInitialLoad(true);
 
 		assertTrue(definition.buildMirroredDocument(fromSystemProperties()).loadDocumentsRouted());
 		assertTrue(definition.buildMirroredDocument(fromSystemProperties()).writeBackPatchedDocuments());

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
@@ -61,7 +61,8 @@ public class MirroredObjectWriterTest {
 		anotherMirroredDocument =
 				MirroredObjectDefinition.create(TestSpaceOtherObject.class)
 										.keepPersistent(true)
-										.persistInstanceId(true)
+										.persistInstanceId()
+										.and()
 										.documentPatches(patches2)
 										.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 		DocumentPatch[] patches1 = {};

--- a/ymer/src/test/java/com/avanza/ymer/PersistedInstanceIdRecalculationServiceTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/PersistedInstanceIdRecalculationServiceTest.java
@@ -21,6 +21,7 @@ import static com.avanza.ymer.TestSpaceMirrorObjectDefinitions.TEST_SPACE_OBJECT
 import static com.avanza.ymer.util.GigaSpacesInstanceIdUtil.getInstanceId;
 import static com.j_spaces.core.Constants.Mirror.FULL_MIRROR_SERVICE_CLUSTER_PARTITIONS_COUNT;
 import static java.util.stream.Collectors.toList;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.hasItem;
@@ -29,6 +30,8 @@ import static org.junit.Assert.assertThrows;
 import static uk.org.webcompere.systemstubs.SystemStubs.execute;
 
 import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import org.bson.Document;
@@ -43,7 +46,6 @@ import org.springframework.data.mongodb.core.index.IndexInfo;
 
 import com.avanza.gs.test.PuConfigurers;
 import com.avanza.gs.test.RunningPu;
-import com.gigaspaces.sync.SpaceSynchronizationEndpoint;
 import com.mongodb.client.MongoCollection;
 
 import uk.org.webcompere.systemstubs.properties.SystemProperties;
@@ -54,14 +56,6 @@ public class PersistedInstanceIdRecalculationServiceTest {
 	public static final MirrorEnvironment mirrorEnvironment = new MirrorEnvironment();
 
 	private final MongoCollection<Document> collection = mirrorEnvironment.getMongoTemplate().getCollection(TEST_SPACE_OBJECT.collectionName());
-
-	private final PersistedInstanceIdRecalculationService target;
-
-	public PersistedInstanceIdRecalculationServiceTest() {
-		TestSpaceMirrorFactory testSpaceMirrorFactory = new TestSpaceMirrorFactory(mirrorEnvironment.getMongoTemplate().getMongoDbFactory());
-		SpaceSynchronizationEndpoint spaceSynchronizationEndpoint = testSpaceMirrorFactory.createSpaceSynchronizationEndpoint();
-		target = ((YmerSpaceSynchronizationEndpoint) spaceSynchronizationEndpoint).getPersistedInstanceIdRecalculationService();
-	}
 
 	@Before
 	public void setUp() {
@@ -98,19 +92,49 @@ public class PersistedInstanceIdRecalculationServiceTest {
 	}
 
 	@Test
+	public void shouldStartRecalculationJobOnStartup() throws Exception {
+		int numberOfInstances = 14;
+		Properties testProperties = new Properties();
+		testProperties.setProperty("ymer.com.avanza.ymer.TestSpaceObject.recalculateInstanceIdOnStartup", "true");
+		testProperties.setProperty("ymer.com.avanza.ymer.TestSpaceObject.recalculateInstanceIdWithDelay", "1");
+
+		execute(() -> {
+			try (RunningPu mirrorPu = PuConfigurers.mirrorPu("classpath:/test-mirror-pu.xml")
+					.contextProperty("exportExceptionHandlerMBean", "false")
+					.contextProperty(FULL_MIRROR_SERVICE_CLUSTER_PARTITIONS_COUNT, String.valueOf(numberOfInstances))
+					.parentContext(mirrorEnvironment.getMongoClientContext())
+					.configure()) {
+				mirrorPu.start();
+
+				await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> verifyCollection(numberOfInstances));
+			}
+		}, new SystemProperties(testProperties));
+	}
+
+	@Test
 	public void shouldRecalculateInstanceIdUsingNumberOfInstancesFromSystemProperty() throws Exception {
 		int numberOfInstances = 32;
 
-		execute(() -> {
-			target.recalculatePersistedInstanceId();
-
-			verifyCollection(numberOfInstances);
-		}, new SystemProperties("cluster.partitions", String.valueOf(numberOfInstances)));
+		try (YmerSpaceSynchronizationEndpoint endpoint = createSpaceSynchronizationEndpoint()) {
+			PersistedInstanceIdRecalculationService target = endpoint.getPersistedInstanceIdRecalculationService();
+			execute(() -> {
+				target.recalculatePersistedInstanceId();
+				verifyCollection(numberOfInstances);
+			}, new SystemProperties("cluster.partitions", String.valueOf(numberOfInstances)));
+		}
 	}
 
 	@Test
 	public void shouldThrowExceptionWhenNumberOfInstancesCannotBeDetermined() {
-		assertThrows(IllegalStateException.class, target::recalculatePersistedInstanceId);
+		try (YmerSpaceSynchronizationEndpoint endpoint = createSpaceSynchronizationEndpoint()) {
+			PersistedInstanceIdRecalculationService target = endpoint.getPersistedInstanceIdRecalculationService();
+			assertThrows(IllegalStateException.class, target::recalculatePersistedInstanceId);
+		}
+	}
+
+	private static YmerSpaceSynchronizationEndpoint createSpaceSynchronizationEndpoint() {
+		TestSpaceMirrorFactory testSpaceMirrorFactory = new TestSpaceMirrorFactory(mirrorEnvironment.getMongoTemplate().getMongoDbFactory());
+		return (YmerSpaceSynchronizationEndpoint) testSpaceMirrorFactory.createSpaceSynchronizationEndpoint();
 	}
 
 	private void verifyCollection(int numberOfInstances) {

--- a/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
+++ b/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
@@ -26,7 +26,8 @@ public class TestSpaceMirrorObjectDefinitions  {
 	public static final MirroredObjectDefinition<TestSpaceObject> TEST_SPACE_OBJECT =
 			MirroredObjectDefinition.create(TestSpaceObject.class)
 					.loadDocumentsRouted(true)
-					.persistInstanceId(true)
+					.persistInstanceId()
+					.and()
 					.documentPatches(new TestSpaceObjectV1Patch(), new TestSpaceObjectV2Patch());
 
 	public static final MirroredObjectDefinition<TestSpaceOtherObject> TEST_SPACE_OTHER_OBJECT =


### PR DESCRIPTION
* Triggers recalculation after a configured delay after application startup
* Default configuration is to execute the recalculation job 60 minutes after startup
* `YmerSpaceSynchronizationEndpoint` needs to be a Spring-managed bean to execute the job at startup
* Properties related to instance id persisting are now grouped in a separate configuration class inspired by Spring Security config
  This can create a flowing config like the following example:
```
MirroredObjectDefinition.create(TestSpaceObject.class)
    .persistInstanceId()
        .recalculateOnStartup(true)
        .recalculateWithDelay(3_600)
    .and()
    .loadDocumentsRouted(true)
```