### PR TITLE
TP-820: Add support for calculating next number of instances

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/DocumentCollection.java
@@ -94,5 +94,7 @@ interface DocumentCollection {
 
 		void updatePartialByIds(Set<Object> ids, Map<String, Object> fieldsToSet);
 
+		void unsetFieldsPartialByIds(Set<Object> ids, Set<String> fieldsToUnset);
+
 	}
 }

--- a/ymer/src/main/java/com/avanza/ymer/InstanceMetadata.java
+++ b/ymer/src/main/java/com/avanza/ymer/InstanceMetadata.java
@@ -20,22 +20,15 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 final class InstanceMetadata {
-	private final Integer instanceId;
 	private final Integer numberOfInstances;
 	private final Integer nextNumberOfInstances;
 
 	public InstanceMetadata(
-			@Nullable Integer instanceId,
 			@Nullable Integer numberOfInstances,
 			@Nullable Integer nextNumberOfInstances
 	) {
-		this.instanceId = instanceId;
 		this.numberOfInstances = numberOfInstances;
 		this.nextNumberOfInstances = nextNumberOfInstances;
-	}
-
-	public Optional<Integer> getInstanceId() {
-		return Optional.ofNullable(instanceId);
 	}
 
 	public Optional<Integer> getNumberOfInstances() {

--- a/ymer/src/main/java/com/avanza/ymer/InstanceMetadata.java
+++ b/ymer/src/main/java/com/avanza/ymer/InstanceMetadata.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+final class InstanceMetadata {
+	private final Integer instanceId;
+	private final Integer numberOfInstances;
+	private final Integer nextNumberOfInstances;
+
+	public InstanceMetadata(
+			@Nullable Integer instanceId,
+			@Nullable Integer numberOfInstances,
+			@Nullable Integer nextNumberOfInstances
+	) {
+		this.instanceId = instanceId;
+		this.numberOfInstances = numberOfInstances;
+		this.nextNumberOfInstances = nextNumberOfInstances;
+	}
+
+	public Optional<Integer> getInstanceId() {
+		return Optional.ofNullable(instanceId);
+	}
+
+	public Optional<Integer> getNumberOfInstances() {
+		return Optional.ofNullable(numberOfInstances);
+	}
+
+	public Optional<Integer> getNextNumberOfInstances() {
+		return Optional.ofNullable(nextNumberOfInstances);
+	}
+}

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
@@ -15,10 +15,11 @@
  */
 package com.avanza.ymer;
 
+import static com.avanza.ymer.PersistedInstanceIdUtil.getInstanceIdFieldName;
+import static com.avanza.ymer.util.GigaSpacesInstanceIdUtil.getInstanceId;
+
 import java.lang.reflect.Method;
 import java.time.Duration;
-
-import javax.annotation.Nullable;
 
 import org.bson.Document;
 
@@ -116,12 +117,12 @@ final class MirroredObject<T> {
 		document.put(DOCUMENT_FORMAT_VERSION_PROPERTY, version);
 	}
 
-	void setDocumentAttributes(Document document, T spaceObject, @Nullable Integer instanceId) {
+	void setDocumentAttributes(Document document, T spaceObject, InstanceMetadata metadata) {
 		setDocumentVersion(document);
 		if (loadDocumentsRouted || persistInstanceId) {
 			setRoutingKey(document, spaceObject);
 			if (persistInstanceId) {
-				setInstanceId(document, instanceId);
+				setInstanceIdFields(document, metadata);
 			}
 		}
 	}
@@ -137,10 +138,21 @@ final class MirroredObject<T> {
 		}
 	}
 
-	private void setInstanceId(Document document, @Nullable Integer instanceId) {
-		if (instanceId != null) {
-			document.put(DOCUMENT_INSTANCE_ID, instanceId);
-		}
+	private void setInstanceIdFields(Document document, InstanceMetadata metadata) {
+		// set current instance id for current amount of partitions
+		metadata.getInstanceId().ifPresent(instanceId -> {
+			metadata.getNumberOfInstances().ifPresent(numberOfInstances ->
+					document.put(getInstanceIdFieldName(numberOfInstances), instanceId)
+			);
+		});
+
+		// set instance id calculated using the next amount of partitions
+		metadata.getNextNumberOfInstances().ifPresent(nextNumberOfInstances -> {
+			if (metadata.getNumberOfInstances().isEmpty() || !metadata.getNumberOfInstances().get().equals(nextNumberOfInstances)) {
+				int nextInstanceId = getInstanceId(document.get(DOCUMENT_ROUTING_KEY), nextNumberOfInstances);
+				document.put(getInstanceIdFieldName(nextNumberOfInstances), nextInstanceId);
+			}
+		});
 	}
 
 	int getCurrentVersion() {

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
@@ -47,8 +47,8 @@ final class MirroredObject<T> {
 	private final boolean writeBackPatchedDocuments;
 	private final boolean loadDocumentsRouted;
 	private final boolean persistInstanceId;
-	private final boolean recalculateInstanceIdOnStartup;
-	private final Duration recalculateInstanceIdWithDelay;
+	private final boolean triggerInstanceIdCalculationOnStartup;
+	private final Duration triggerInstanceIdCalculationWithDelay;
 	private final boolean keepPersistent;
     private final String collectionName;
 	private final TemplateFactory customInitialLoadTemplateFactory;
@@ -63,8 +63,8 @@ final class MirroredObject<T> {
 
 		PersistInstanceIdDefinition<?> persistInstanceId = override.persistInstanceId(definition);
         this.persistInstanceId = persistInstanceId.isEnabled();
-		this.recalculateInstanceIdOnStartup = persistInstanceId.isRecalculateOnStartup();
-		this.recalculateInstanceIdWithDelay = persistInstanceId.getRecalculateWithDelay();
+		this.triggerInstanceIdCalculationOnStartup = persistInstanceId.isTriggerCalculationOnStartup();
+		this.triggerInstanceIdCalculationWithDelay = persistInstanceId.getTriggerCalculationWithDelay();
 
         this.keepPersistent = definition.keepPersistent();
         this.collectionName = definition.collectionName();
@@ -225,12 +225,12 @@ final class MirroredObject<T> {
 		return persistInstanceId;
 	}
 
-	boolean recalculateInstanceIdOnStartup() {
-		return recalculateInstanceIdOnStartup;
+	boolean triggerInstanceIdCalculationOnStartup() {
+		return triggerInstanceIdCalculationOnStartup;
 	}
 
-	Duration recalculateInstanceIdWithDelay() {
-		return recalculateInstanceIdWithDelay;
+	Duration triggerInstanceIdCalculationWithDelay() {
+		return triggerInstanceIdCalculationWithDelay;
 	}
 
 	ReadPreference getReadPreference() {

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
@@ -40,7 +40,7 @@ final class MirroredObject<T> {
 
 	public static final String DOCUMENT_FORMAT_VERSION_PROPERTY = "_formatVersion";
 	public static final String DOCUMENT_ROUTING_KEY = "_routingKey";
-	public static final String DOCUMENT_INSTANCE_ID = "_instanceId";
+	public static final String DOCUMENT_INSTANCE_ID_PREFIX = "_instanceId";
 	private final DocumentPatchChain<T> patchChain;
 	private final RoutingKeyExtractor routingKeyExtractor;
 	private final boolean excludeFromInitialLoad;

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinitionsOverride.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinitionsOverride.java
@@ -83,10 +83,10 @@ public interface MirroredObjectDefinitionsOverride {
         public PersistInstanceIdDefinition<?> persistInstanceId(MirroredObjectDefinition<?> definition) {
             PersistInstanceIdDefinition<?> persistInstanceId = PersistInstanceIdDefinition.from(definition.getPersistInstanceId());
             getProperty(definition, "persistInstanceId").ifPresent(persistInstanceId::enabled);
-            getProperty(definition, "recalculateInstanceIdOnStartup").ifPresent(persistInstanceId::recalculateOnStartup);
-            getIntProperty(definition, "recalculateInstanceIdWithDelay")
+            getProperty(definition, "triggerInstanceIdCalculationOnStartup").ifPresent(persistInstanceId::triggerCalculationOnStartup);
+            getIntProperty(definition, "triggerInstanceIdCalculationWithDelay")
                     .map(Duration::ofSeconds)
-                    .ifPresent(persistInstanceId::recalculateWithDelay);
+                    .ifPresent(persistInstanceId::triggerCalculationWithDelay);
             return persistInstanceId;
         }
 

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectLoader.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectLoader.java
@@ -15,7 +15,6 @@
  */
 package com.avanza.ymer;
 
-import static com.avanza.ymer.MirroredObject.DOCUMENT_INSTANCE_ID;
 import static com.avanza.ymer.PersistedInstanceIdUtil.getInstanceIdFieldName;
 import static com.avanza.ymer.PersistedInstanceIdUtil.isIndexForNumberOfPartitions;
 import static java.util.stream.Collectors.toList;
@@ -92,7 +91,7 @@ final class MirroredObjectLoader<T> {
             boolean indexExists = documentCollection.getIndexes()
                     .anyMatch(isIndexForNumberOfPartitions(contextProperties.getPartitionCount()));
             if (indexExists) {
-                Query query = query(new Criteria().orOperator(where(instanceIdField).is(contextProperties.getInstanceId()), where(DOCUMENT_INSTANCE_ID).exists(false)));
+                Query query = query(new Criteria().orOperator(where(instanceIdField).is(contextProperties.getInstanceId()), where(instanceIdField).exists(false)));
                 return documentCollection.findByQuery(query);
             } else {
                 log.warn("Configured to load using persisted instance id, but no index exists for field {}. Will not use instance id when loading.",

--- a/ymer/src/main/java/com/avanza/ymer/MongoDocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/MongoDocumentCollection.java
@@ -141,7 +141,6 @@ final class MongoDocumentCollection implements DocumentCollection {
 	}
 
 	@Override
-	@SuppressWarnings("Convert2Lambda")
 	public void bulkWrite(Consumer<BulkWriter> bulkWriter) {
 		List<WriteModel<Document>> writeModels = new ArrayList<>();
 		bulkWriter.accept(new BulkWriter() {

--- a/ymer/src/main/java/com/avanza/ymer/MongoDocumentCollection.java
+++ b/ymer/src/main/java/com/avanza/ymer/MongoDocumentCollection.java
@@ -148,6 +148,10 @@ final class MongoDocumentCollection implements DocumentCollection {
 			@Override
 			public void updatePartialByIds(Set<Object> ids, Map<String, Object> fieldsToSet) {
 				Bson updates = toUpdates(fieldsToSet);
+				addUpdates(ids, updates);
+			}
+
+			private void addUpdates(Set<Object> ids, Bson updates) {
 				if (ids.isEmpty()) {
 					log.warn("Skipping updates because no ids provided");
 				} else if (updates == null) {
@@ -157,6 +161,12 @@ final class MongoDocumentCollection implements DocumentCollection {
 					UpdateManyModel<Document> updateManyModel = new UpdateManyModel<>(filter, updates);
 					writeModels.add(updateManyModel);
 				}
+			}
+
+			@Override
+			public void unsetFieldsPartialByIds(Set<Object> ids, Set<String> fieldsToUnset) {
+				Bson updates = toFieldDeletes(fieldsToUnset);
+				addUpdates(ids, updates);
 			}
 		});
 		if (writeModels.isEmpty()) {
@@ -214,6 +224,14 @@ final class MongoDocumentCollection implements DocumentCollection {
 	private static Bson toUpdates(Map<String, Object> fieldsToSet) {
 		return fieldsToSet.entrySet().stream()
 				.map(entry -> Updates.set(entry.getKey(), entry.getValue()))
+				.reduce(Updates::combine)
+				.orElse(null);
+	}
+
+	@Nullable
+	private static Bson toFieldDeletes(Set<String> fieldsToUnset) {
+		return fieldsToUnset.stream()
+				.map(Updates::unset)
 				.reduce(Updates::combine)
 				.orElse(null);
 	}

--- a/ymer/src/main/java/com/avanza/ymer/PersistInstanceIdDefinition.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistInstanceIdDefinition.java
@@ -23,8 +23,8 @@ public final class PersistInstanceIdDefinition<T> {
 
 	private final MirroredObjectDefinition<T> parent;
 	private boolean enabled;
-	private boolean recalculateOnStartup;
-	private Duration recalculateWithDelay = DEFAULT_DELAY;
+	private boolean triggerCalculationOnStartup;
+	private Duration triggerCalculationWithDelay = DEFAULT_DELAY;
 
 	PersistInstanceIdDefinition(MirroredObjectDefinition<T> parent) {
 		this.parent = parent;
@@ -33,12 +33,12 @@ public final class PersistInstanceIdDefinition<T> {
 	static <T> PersistInstanceIdDefinition<T> from(PersistInstanceIdDefinition<T> from) {
 		return new PersistInstanceIdDefinition<>(from.getParent())
 				.enabled(from.enabled)
-				.recalculateOnStartup(from.recalculateOnStartup)
-				.recalculateWithDelay(from.recalculateWithDelay);
+				.triggerCalculationOnStartup(from.triggerCalculationOnStartup)
+				.triggerCalculationWithDelay(from.triggerCalculationWithDelay);
 	}
 
 	public PersistInstanceIdDefinition<T> enableWithDefaults() {
-		return enabled(true).recalculateOnStartup(true);
+		return enabled(true).triggerCalculationOnStartup(true);
 	}
 
 	/**
@@ -50,31 +50,32 @@ public final class PersistInstanceIdDefinition<T> {
 	}
 
 	/**
-	 * Whether to recalculate persisted instance id on startup if necessary.
-	 * If enabled, instance id will be recalculated on startup (with a delay configured by
-	 * {@code delayRecalculationOnStartupWithSeconds}).
-	 * If disabled, instance id will only be recalculated when manually called.
+	 * Whether to calculate persisted instance id on startup if necessary.
+	 * When enabled, instance id will be calculated and persisted on startup (with a delay configured by
+	 * {@code triggerCalculationWithDelay}).
+	 * When disabled, {@link PersistedInstanceIdCalculationService} will only be run when manually called.
 	 * This defaults to {@code true} when persisting instance id is enabled.
 	 *
 	 * Automatically starting this job requires {@link YmerSpaceSynchronizationEndpoint} to be handled
 	 * as a Spring bean.
 	 */
-	public PersistInstanceIdDefinition<T> recalculateOnStartup(boolean recalculateOnStartup) {
-		this.recalculateOnStartup = recalculateOnStartup;
+	public PersistInstanceIdDefinition<T> triggerCalculationOnStartup(boolean triggerCalculationOnStartup) {
+		this.triggerCalculationOnStartup = triggerCalculationOnStartup;
 		return this;
 	}
 
 	/**
-	 * Delay starting recalculation of persisted instance id with the specified delay after startup.
+	 * Delay triggering of calculation of persisted instance id with the specified delay after startup.
 	 * This is done to reduce load on database during initial load of data.
+	 * This property only has an effect when {@code triggerCalculationOnStartup} is enabled.
 	 */
-	public PersistInstanceIdDefinition<T> recalculateWithDelay(Duration recalculateOnStartupDelay) {
-		this.recalculateWithDelay = recalculateOnStartupDelay;
+	public PersistInstanceIdDefinition<T> triggerCalculationWithDelay(Duration triggerCalculationWithDelay) {
+		this.triggerCalculationWithDelay = triggerCalculationWithDelay;
 		return this;
 	}
 
 	/**
-	 * Return the MirroredObjectDefinition when done configuring the PersistInstanceIdDefinition.
+	 * Return the {@code MirroredObjectDefinition} when done configuring the {@code PersistInstanceIdDefinition}.
 	 * This is useful for method chaining.
 	 *
 	 * @return the MirroredObjectDefinition for further customizations
@@ -91,11 +92,11 @@ public final class PersistInstanceIdDefinition<T> {
 		return enabled;
 	}
 
-	boolean isRecalculateOnStartup() {
-		return recalculateOnStartup;
+	boolean isTriggerCalculationOnStartup() {
+		return triggerCalculationOnStartup;
 	}
 
-	Duration getRecalculateWithDelay() {
-		return recalculateWithDelay;
+	Duration getTriggerCalculationWithDelay() {
+		return triggerCalculationWithDelay;
 	}
 }

--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdCalculationServiceMBean.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdCalculationServiceMBean.java
@@ -15,10 +15,10 @@
  */
 package com.avanza.ymer;
 
-public interface PersistedInstanceIdRecalculationServiceMBean {
+public interface PersistedInstanceIdCalculationServiceMBean {
 
-	void recalculatePersistedInstanceId();
+	void calculatePersistedInstanceId();
 
-	void recalculatePersistedInstanceId(String collectionName);
+	void calculatePersistedInstanceId(String collectionName);
 
 }

--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdRecalculationService.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdRecalculationService.java
@@ -15,7 +15,7 @@
  */
 package com.avanza.ymer;
 
-import static com.avanza.ymer.MirroredObject.DOCUMENT_INSTANCE_ID;
+import static com.avanza.ymer.MirroredObject.DOCUMENT_INSTANCE_ID_PREFIX;
 import static com.avanza.ymer.MirroredObject.DOCUMENT_ROUTING_KEY;
 import static com.avanza.ymer.PersistedInstanceIdUtil.getInstanceIdFieldName;
 import static com.avanza.ymer.PersistedInstanceIdUtil.isIndexForAnyNumberOfPartitionsIn;
@@ -132,7 +132,7 @@ public class PersistedInstanceIdRecalculationService implements PersistedInstanc
 	}
 
 	private Predicate<IndexInfo> isInstanceIdIndex() {
-		return indexInfo -> indexInfo.getIndexFields().size() == 1 && indexInfo.getIndexFields().get(0).getKey().startsWith(DOCUMENT_INSTANCE_ID);
+		return indexInfo -> indexInfo.getIndexFields().size() == 1 && indexInfo.getIndexFields().get(0).getKey().startsWith(DOCUMENT_INSTANCE_ID_PREFIX);
 	}
 
 	private void recalculatePersistedInstanceId(String collectionName, Set<Integer> numberOfPartitionsSet) {

--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdUtil.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import static com.avanza.ymer.MirroredObject.DOCUMENT_INSTANCE_ID;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.springframework.data.mongodb.core.index.IndexInfo;
+
+final class PersistedInstanceIdUtil {
+
+	private PersistedInstanceIdUtil() {
+	}
+
+	public static Predicate<IndexInfo> isIndexForAnyNumberOfPartitionsIn(Set<Integer> numberOfPartitions) {
+		return indexInfo -> numberOfPartitions.stream().anyMatch(fieldName -> isIndexForNumberOfPartitions(fieldName).test(indexInfo));
+	}
+
+	public static Predicate<IndexInfo> isIndexForNumberOfPartitions(int numberOfPartitions) {
+		final String fieldName = getInstanceIdFieldName(numberOfPartitions);
+		return indexInfo -> indexInfo.isIndexForFields(List.of(fieldName));
+	}
+
+	public static String getInstanceIdFieldName(int numberOfPartitions) {
+		return DOCUMENT_INSTANCE_ID + "_" + numberOfPartitions;
+	}
+}

--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdUtil.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdUtil.java
@@ -15,7 +15,7 @@
  */
 package com.avanza.ymer;
 
-import static com.avanza.ymer.MirroredObject.DOCUMENT_INSTANCE_ID;
+import static com.avanza.ymer.MirroredObject.DOCUMENT_INSTANCE_ID_PREFIX;
 
 import java.util.List;
 import java.util.Set;
@@ -38,6 +38,6 @@ final class PersistedInstanceIdUtil {
 	}
 
 	public static String getInstanceIdFieldName(int numberOfPartitions) {
-		return DOCUMENT_INSTANCE_ID + "_" + numberOfPartitions;
+		return DOCUMENT_INSTANCE_ID_PREFIX + "_" + numberOfPartitions;
 	}
 }

--- a/ymer/src/main/java/com/avanza/ymer/ReloadableYmerProperties.java
+++ b/ymer/src/main/java/com/avanza/ymer/ReloadableYmerProperties.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public final class ReloadableYmerProperties {
+
+	private final Supplier<Optional<Integer>> nextNumberOfInstances;
+
+	private ReloadableYmerProperties(Supplier<Optional<Integer>> nextNumberOfInstances) {
+		this.nextNumberOfInstances = requireNonNull(nextNumberOfInstances);
+	}
+
+	public Optional<Integer> getNextNumberOfInstances() {
+		return nextNumberOfInstances.get()
+				.filter(numberOfInstances -> numberOfInstances > 0);
+	}
+
+	static ReloadablePropertiesBuilder builder() {
+		return new ReloadablePropertiesBuilder();
+	}
+
+	public static final class ReloadablePropertiesBuilder {
+		private Supplier<Optional<Integer>> nextNumberOfInstances = Optional::empty;
+
+		private ReloadablePropertiesBuilder() {
+		}
+
+		/**
+		 * Sets a supplier returning the coming amount of partitions planned for the space after restart.
+		 * This is designed to be used in combination with {@link MirroredObjectDefinition#persistInstanceId()}.
+		 * <p>
+		 * When writing the instance ID field, both the instance ID using the current number of partitions and the next
+		 * number of partitions will be set to the document. It will also be used when calling {@link PersistedInstanceIdRecalculationService}.
+		 * <p>
+		 * Only values from 1 and above are valid, other values will be ignored.
+		 */
+		public ReloadablePropertiesBuilder nextNumberOfInstances(Supplier<Optional<Integer>> nextNumberOfInstances) {
+			this.nextNumberOfInstances = nextNumberOfInstances;
+			return this;
+		}
+
+		public ReloadableYmerProperties build() {
+			return new ReloadableYmerProperties(nextNumberOfInstances);
+		}
+	}
+}

--- a/ymer/src/main/java/com/avanza/ymer/ReloadableYmerProperties.java
+++ b/ymer/src/main/java/com/avanza/ymer/ReloadableYmerProperties.java
@@ -48,7 +48,7 @@ public final class ReloadableYmerProperties {
 		 * This is designed to be used in combination with {@link MirroredObjectDefinition#persistInstanceId()}.
 		 * <p>
 		 * When writing the instance ID field, both the instance ID using the current number of partitions and the next
-		 * number of partitions will be set to the document. It will also be used when calling {@link PersistedInstanceIdRecalculationService}.
+		 * number of partitions will be set to the document. It will also be used when calling {@link PersistedInstanceIdCalculationService}.
 		 * <p>
 		 * Only values from 1 and above are valid, other values will be ignored.
 		 */

--- a/ymer/src/main/java/com/avanza/ymer/SpaceMirrorContext.java
+++ b/ymer/src/main/java/com/avanza/ymer/SpaceMirrorContext.java
@@ -20,8 +20,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.annotation.Nullable;
-
 import org.bson.Document;
 
 import com.avanza.ymer.plugin.PreWriteProcessor;
@@ -109,11 +107,11 @@ final class SpaceMirrorContext {
 	 * Converts the given space object to a mongo document and appends
 	 * the current document version to the created mongo document. <p>
 	 */
-	<T> Document toVersionedDocument(T spaceObject, @Nullable Integer instanceId) {
+	<T> Document toVersionedDocument(T spaceObject, InstanceMetadata metadata) {
 		@SuppressWarnings("unchecked")
 		MirroredObject<T> mirroredObject = (MirroredObject<T>) this.mirroredObjects.getMirroredObject(spaceObject.getClass());
 		Document document = this.documentConverter.convertToBsonDocument(spaceObject);
-		mirroredObject.setDocumentAttributes(document, spaceObject, instanceId);
+		mirroredObject.setDocumentAttributes(document, spaceObject, metadata);
 		return document;
 	}
 

--- a/ymer/src/main/java/com/avanza/ymer/YmerFactory.java
+++ b/ymer/src/main/java/com/avanza/ymer/YmerFactory.java
@@ -155,7 +155,7 @@ public final class YmerFactory implements ApplicationContextAware {
 			ymerSpaceSynchronizationEndpoint.registerExceptionHandlerMBean();
 		}
 		if (mirroredObjects.getMirroredObjects().stream().anyMatch(MirroredObject::persistInstanceId)) {
-			ymerSpaceSynchronizationEndpoint.registerPersistedInstanceIdRecalculationServiceMBean();
+			ymerSpaceSynchronizationEndpoint.registerPersistedInstanceIdCalculationServiceMBean();
 		}
 		if (applicationContext != null) {
 			ymerSpaceSynchronizationEndpoint.setApplicationContext(applicationContext);

--- a/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
+++ b/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
@@ -15,7 +15,6 @@
  */
 package com.avanza.ymer;
 
-import static com.avanza.ymer.util.GigaSpacesInstanceIdUtil.extractInstanceIdFromSpaceName;
 import static java.util.stream.Collectors.toList;
 
 import java.lang.management.ManagementFactory;
@@ -72,13 +71,11 @@ final class YmerSpaceSynchronizationEndpoint extends SpaceSynchronizationEndpoin
 
 	@Override
 	public void onOperationsBatchSynchronization(OperationsBatchData batchData) {
-		InstanceMetadata metadata = getInstanceMetadata(batchData.getSourceDetails().getName());
-		mirroredObjectWriter.executeBulk(metadata, batchData);
+		mirroredObjectWriter.executeBulk(getInstanceMetadata(), batchData);
 	}
 
-	private InstanceMetadata getInstanceMetadata(String spaceName) {
-		Integer instanceId = extractInstanceIdFromSpaceName(spaceName).orElse(null);
-		return new InstanceMetadata(instanceId, currentNumberOfPartitions, ymerProperties.getNextNumberOfInstances().orElse(null));
+	private InstanceMetadata getInstanceMetadata() {
+		return new InstanceMetadata(currentNumberOfPartitions, ymerProperties.getNextNumberOfInstances().orElse(null));
 	}
 
 	@Override

--- a/ymer/src/main/java/com/avanza/ymer/util/GigaSpacesInstanceIdUtil.java
+++ b/ymer/src/main/java/com/avanza/ymer/util/GigaSpacesInstanceIdUtil.java
@@ -15,19 +15,10 @@
  */
 package com.avanza.ymer.util;
 
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.annotation.Nullable;
-
-import org.springframework.util.StringUtils;
-
 /**
  * @see com.gigaspaces.internal.remoting.routing.partitioned.PartitionedClusterUtils
  */
 public final class GigaSpacesInstanceIdUtil {
-	private static final Pattern PARTITION_ID_PATTERN = Pattern.compile("_container(\\d+)");
 
 	private GigaSpacesInstanceIdUtil() {
 	}
@@ -37,23 +28,6 @@ public final class GigaSpacesInstanceIdUtil {
 	 */
 	public static int getInstanceId(Object routingKey, int partitionCount) {
 		return safeAbsoluteValue(routingKey.hashCode()) % partitionCount + 1;
-	}
-
-	/**
-	 * @see com.gigaspaces.internal.remoting.routing.partitioned.PartitionedClusterUtils#extractPartitionIdFromSpaceName(String)
-	 */
-	public static Optional<Integer> extractInstanceIdFromSpaceName(@Nullable String spaceName) {
-		// Format: qaSpace_container2_1:qaSpace
-		if (StringUtils.isEmpty(spaceName)) {
-			return Optional.empty();
-		}
-
-		Matcher matcher = PARTITION_ID_PATTERN.matcher(spaceName);
-		if (matcher.find()) {
-			return Optional.of(Integer.valueOf(matcher.group(1)));
-		} else {
-			return Optional.empty();
-		}
 	}
 
 	private static int safeAbsoluteValue(int value) {

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectLoaderTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectLoaderTest.java
@@ -15,7 +15,6 @@
  */
 package com.avanza.ymer;
 
-import static com.avanza.ymer.MirroredObject.DOCUMENT_INSTANCE_ID;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -99,27 +98,29 @@ public class MirroredObjectLoaderTest {
 				.and()
 				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 
+		String documentInstanceIdField = PersistedInstanceIdUtil.getInstanceIdFieldName(contextProperties.getPartitionCount());
+
 		Document doc1 = new Document();
 		doc1.put("_id", 2);
 		doc1.put("spaceRouting", 1);
-		doc1.put(DOCUMENT_INSTANCE_ID, 1);
+		doc1.put(documentInstanceIdField, 1);
 
 		final Document doc2 = new Document();
 		doc2.put("_id", 3);
 		doc2.put("spaceRouting", 2);
-		doc2.put(DOCUMENT_INSTANCE_ID, 2);
+		doc2.put(documentInstanceIdField, 2);
 
 		final Document doc3 = new Document();
 		doc3.put("_id", 4);
 		doc3.put("spaceRouting", 1);
-		doc3.remove(DOCUMENT_INSTANCE_ID); // documents with no instance id should be loaded then filtered in java
+		doc3.remove(documentInstanceIdField); // documents with no instance id should be loaded then filtered in java
 
 		final Document doc4 = new Document();
 		doc4.put("_id", 5);
 		doc4.put("spaceRouting", 2);
-		doc4.remove(DOCUMENT_INSTANCE_ID); // documents with no instance id should be loaded then filtered in java
+		doc4.remove(documentInstanceIdField); // documents with no instance id should be loaded then filtered in java
 
-		documentCollection.createIndex(new Document(DOCUMENT_INSTANCE_ID, 1), new IndexOptions().name("_index" + DOCUMENT_INSTANCE_ID + "_numberOfPartitions_" + contextProperties.getPartitionCount()));
+		documentCollection.createIndex(new Document(documentInstanceIdField, 1), new IndexOptions());
 
 		documentCollection.insertAll(doc1, doc2, doc3, doc4);
 

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectTest.java
@@ -16,6 +16,7 @@
 package com.avanza.ymer;
 
 import static com.avanza.ymer.MirroredObjectDefinitionsOverride.fromSystemProperties;
+import static com.avanza.ymer.PersistedInstanceIdUtil.getInstanceIdFieldName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -24,7 +25,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.bson.Document;
 import org.junit.Test;
@@ -348,10 +351,26 @@ public class MirroredObjectTest {
 		Document dbObject = new Document();
 
 		int routingKey = 23;
-		int instanceId = 2;
-		document.setDocumentAttributes(dbObject, new MirroredType(routingKey), instanceId);
+		InstanceMetadata metadata = new InstanceMetadata(2, 2, null);
+		document.setDocumentAttributes(dbObject, new MirroredType(routingKey), metadata);
 		assertEquals(routingKey, dbObject.get(MirroredObject.DOCUMENT_ROUTING_KEY));
-		assertEquals(instanceId, dbObject.get(MirroredObject.DOCUMENT_INSTANCE_ID));
+		assertEquals(2, dbObject.get(getInstanceIdFieldName(2)));
+	}
+
+	@Test
+	public void setsNextInstanceIdAndRoutingKeyForPersistInstanceId() throws Exception {
+		MirroredObject<MirroredType> document = MirroredObjectDefinition.create(MirroredType.class)
+				.persistInstanceId()
+				.and()
+				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
+		Document dbObject = new Document();
+
+		int routingKey = 23;
+		InstanceMetadata metadata = new InstanceMetadata(2, 2, 3);
+		document.setDocumentAttributes(dbObject, new MirroredType(routingKey), metadata);
+		assertEquals(routingKey, dbObject.get(MirroredObject.DOCUMENT_ROUTING_KEY));
+		assertEquals(2, dbObject.get(getInstanceIdFieldName(2)));
+		assertEquals(3, dbObject.get(getInstanceIdFieldName(3)));
 	}
 
 	@Test
@@ -360,12 +379,35 @@ public class MirroredObjectTest {
 				.persistInstanceId()
 				.and()
 				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
+		int routingKey = 23;
+
+		// instanceId null
+		Document nullInstanceId = new Document();
+		InstanceMetadata nullInstanceIdMetadata = new InstanceMetadata(null, 2, null);
+		document.setDocumentAttributes(nullInstanceId, new MirroredType(routingKey), nullInstanceIdMetadata);
+		assertEquals(routingKey, nullInstanceId.get(MirroredObject.DOCUMENT_ROUTING_KEY));
+		assertNoInstanceIdFieldsAreSet(nullInstanceId);
+
+		// numberOfInstances null
+		Document nullNumberOfPartitions = new Document();
+		InstanceMetadata nullNumberOfPartitionsMetadata = new InstanceMetadata(2, null, null);
+		document.setDocumentAttributes(nullNumberOfPartitions, new MirroredType(routingKey), nullNumberOfPartitionsMetadata);
+		assertEquals(routingKey, nullNumberOfPartitions.get(MirroredObject.DOCUMENT_ROUTING_KEY));
+		assertNoInstanceIdFieldsAreSet(nullNumberOfPartitions);
+	}
+
+	@Test
+	public void willAlwaysCalculateNextNumberOfPartitionsIfSet() throws Exception {
+		MirroredObject<MirroredType> document = MirroredObjectDefinition.create(MirroredType.class)
+				.persistInstanceId()
+				.and()
+				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 		Document dbObject = new Document();
 
 		int routingKey = 23;
-		document.setDocumentAttributes(dbObject, new MirroredType(routingKey), null);
+		document.setDocumentAttributes(dbObject, new MirroredType(routingKey), new InstanceMetadata(null, null, 2));
 		assertEquals(routingKey, dbObject.get(MirroredObject.DOCUMENT_ROUTING_KEY));
-		assertFalse(dbObject.containsKey(MirroredObject.DOCUMENT_INSTANCE_ID));
+		assertEquals(2, dbObject.get(getInstanceIdFieldName(2)));
 	}
 
 	@Test
@@ -391,6 +433,11 @@ public class MirroredObjectTest {
 		assertFalse(definition.buildMirroredDocument(fromSystemProperties()).writeBackPatchedDocuments());
 		assertFalse(definition.buildMirroredDocument(fromSystemProperties()).excludeFromInitialLoad());
 		assertFalse(definition.buildMirroredDocument(fromSystemProperties()).persistInstanceId());
+	}
+
+	private static void assertNoInstanceIdFieldsAreSet(Document document) {
+		Set<String> fields = document.keySet().stream().filter(it -> it.startsWith(MirroredObject.DOCUMENT_INSTANCE_ID)).collect(Collectors.toSet());
+		assertTrue("Expected no instance id fields to exist, but found " + fields, fields.isEmpty());
 	}
 
 	static class MirroredType {

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectTest.java
@@ -428,7 +428,7 @@ public class MirroredObjectTest {
 	}
 
 	private static void assertNoInstanceIdFieldsAreSet(Document document) {
-		Set<String> fields = document.keySet().stream().filter(it -> it.startsWith(MirroredObject.DOCUMENT_INSTANCE_ID)).collect(Collectors.toSet());
+		Set<String> fields = document.keySet().stream().filter(it -> it.startsWith(MirroredObject.DOCUMENT_INSTANCE_ID_PREFIX)).collect(Collectors.toSet());
 		assertTrue("Expected no instance id fields to exist, but found " + fields, fields.isEmpty());
 	}
 

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectTest.java
@@ -351,7 +351,7 @@ public class MirroredObjectTest {
 		Document dbObject = new Document();
 
 		int routingKey = 23;
-		InstanceMetadata metadata = new InstanceMetadata(2, 2, null);
+		InstanceMetadata metadata = new InstanceMetadata(2, null);
 		document.setDocumentAttributes(dbObject, new MirroredType(routingKey), metadata);
 		assertEquals(routingKey, dbObject.get(MirroredObject.DOCUMENT_ROUTING_KEY));
 		assertEquals(2, dbObject.get(getInstanceIdFieldName(2)));
@@ -366,7 +366,7 @@ public class MirroredObjectTest {
 		Document dbObject = new Document();
 
 		int routingKey = 23;
-		InstanceMetadata metadata = new InstanceMetadata(2, 2, 3);
+		InstanceMetadata metadata = new InstanceMetadata(2, 3);
 		document.setDocumentAttributes(dbObject, new MirroredType(routingKey), metadata);
 		assertEquals(routingKey, dbObject.get(MirroredObject.DOCUMENT_ROUTING_KEY));
 		assertEquals(2, dbObject.get(getInstanceIdFieldName(2)));
@@ -381,16 +381,8 @@ public class MirroredObjectTest {
 				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 		int routingKey = 23;
 
-		// instanceId null
-		Document nullInstanceId = new Document();
-		InstanceMetadata nullInstanceIdMetadata = new InstanceMetadata(null, 2, null);
-		document.setDocumentAttributes(nullInstanceId, new MirroredType(routingKey), nullInstanceIdMetadata);
-		assertEquals(routingKey, nullInstanceId.get(MirroredObject.DOCUMENT_ROUTING_KEY));
-		assertNoInstanceIdFieldsAreSet(nullInstanceId);
-
-		// numberOfInstances null
 		Document nullNumberOfPartitions = new Document();
-		InstanceMetadata nullNumberOfPartitionsMetadata = new InstanceMetadata(2, null, null);
+		InstanceMetadata nullNumberOfPartitionsMetadata = new InstanceMetadata(null, null);
 		document.setDocumentAttributes(nullNumberOfPartitions, new MirroredType(routingKey), nullNumberOfPartitionsMetadata);
 		assertEquals(routingKey, nullNumberOfPartitions.get(MirroredObject.DOCUMENT_ROUTING_KEY));
 		assertNoInstanceIdFieldsAreSet(nullNumberOfPartitions);
@@ -405,7 +397,7 @@ public class MirroredObjectTest {
 		Document dbObject = new Document();
 
 		int routingKey = 23;
-		document.setDocumentAttributes(dbObject, new MirroredType(routingKey), new InstanceMetadata(null, null, 2));
+		document.setDocumentAttributes(dbObject, new MirroredType(routingKey), new InstanceMetadata(null, 2));
 		assertEquals(routingKey, dbObject.get(MirroredObject.DOCUMENT_ROUTING_KEY));
 		assertEquals(2, dbObject.get(getInstanceIdFieldName(2)));
 	}

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
@@ -76,7 +76,7 @@ public class MirroredObjectWriterTest {
 		mirrorExceptionSpy = new MirrorExceptionSpy();
 		mirror = new SpaceMirrorContext(mirroredObjects, documentConverter, documentDb, mirrorExceptionSpy, Plugins.empty(), 1);
 		mirroredObjectWriter = new MirroredObjectWriter(mirror, new FakeDocumentWriteExceptionHandler());
-		testMetadata = new InstanceMetadata(1, 1, null);
+		testMetadata = new InstanceMetadata(1, null);
 	}
 
 	@Test
@@ -121,7 +121,7 @@ public class MirroredObjectWriterTest {
 	@Test
 	public void writesCurrentAndNextInstanceId() throws Exception {
 		TestSpaceOtherObject item = new TestSpaceOtherObject("1", "message");
-		InstanceMetadata metadataWithNext = new InstanceMetadata(1, 1, 2);
+		InstanceMetadata metadataWithNext = new InstanceMetadata(1, 2);
 		mirroredObjectWriter.executeBulk(metadataWithNext, FakeBatchData.create(new FakeBulkItem(item, DataSyncOperationType.WRITE)));
 
 		List<Document> persisted = documentDb.getCollection(anotherMirroredDocument.getCollectionName()).findAll().collect(toList());
@@ -133,7 +133,7 @@ public class MirroredObjectWriterTest {
 
 	@Test
 	public void writesOnlyOneWhenCurrentAndNextInstanceIdAreTheSame() throws Exception {
-		InstanceMetadata metadataWithNext = new InstanceMetadata(1, 1, 1);
+		InstanceMetadata metadataWithNext = new InstanceMetadata(1, 1);
 		TestSpaceOtherObject item = new TestSpaceOtherObject("1", "message");
 		mirroredObjectWriter.executeBulk(metadataWithNext, FakeBatchData.create(new FakeBulkItem(item, DataSyncOperationType.WRITE)));
 

--- a/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
@@ -52,6 +52,8 @@ public class MongoDocumentCollectionTest extends DocumentCollectionContract {
 
 	private static final String COLLECTION_NAME = "testcollection";
 
+	private final InstanceMetadata metadata = new InstanceMetadata(2, 2, null);
+
 	@After
 	public void cleanDatabase() {
 		mirrorEnvironment.reset();
@@ -74,12 +76,12 @@ public class MongoDocumentCollectionTest extends DocumentCollectionContract {
 		Document doc1 = new Document();
 		doc1.put("_id", 1);
 		doc1.put("value", "a");
-		mirroredObject.setDocumentAttributes(doc1, new FakeSpaceObject(1, "a"), 2);
+		mirroredObject.setDocumentAttributes(doc1, new FakeSpaceObject(1, "a"), metadata);
 
 		final Document doc2 = new Document();
 		doc2.put("_id", 2);
 		doc2.put("value", "b");
-		mirroredObject.setDocumentAttributes(doc2, new FakeSpaceObject(2, "b"), 2);
+		mirroredObject.setDocumentAttributes(doc2, new FakeSpaceObject(2, "b"), metadata);
 
 		// Objects WITHOUT routed field
 		final Document doc3 = new Document();
@@ -125,12 +127,12 @@ public class MongoDocumentCollectionTest extends DocumentCollectionContract {
 		Document doc1 = new Document();
 		doc1.put("_id", 1);
 		doc1.put("value", "a");
-		mirroredObject.setDocumentAttributes(doc1, new FakeSpaceObject(1, "a"), 2);
+		mirroredObject.setDocumentAttributes(doc1, new FakeSpaceObject(1, "a"), metadata);
 
 		final Document doc2 = new Document();
 		doc2.put("_id", 2);
 		doc2.put("value", "b");
-		mirroredObject.setDocumentAttributes(doc2, new FakeSpaceObject(2, "b"), 2);
+		mirroredObject.setDocumentAttributes(doc2, new FakeSpaceObject(2, "b"), metadata);
 
 		// Objects WITHOUT routed field
 		final Document doc3 = new Document();

--- a/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MongoDocumentCollectionTest.java
@@ -52,7 +52,7 @@ public class MongoDocumentCollectionTest extends DocumentCollectionContract {
 
 	private static final String COLLECTION_NAME = "testcollection";
 
-	private final InstanceMetadata metadata = new InstanceMetadata(2, 2, null);
+	private final InstanceMetadata metadata = new InstanceMetadata(2, null);
 
 	@After
 	public void cleanDatabase() {

--- a/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorFactory.java
+++ b/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorFactory.java
@@ -15,18 +15,22 @@
  */
 package com.avanza.ymer;
 
-import com.gigaspaces.datasource.SpaceDataSource;
-import com.gigaspaces.sync.SpaceSynchronizationEndpoint;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 
-import java.util.Collection;
-import java.util.Collections;
+import com.gigaspaces.datasource.SpaceDataSource;
+import com.gigaspaces.sync.SpaceSynchronizationEndpoint;
 
 public class TestSpaceMirrorFactory {
 
 	private final MongoDbFactory mongoDbFactory;
+	private final AtomicReference<Integer> nextNumberOfInstances = new AtomicReference<>(null);
 	private boolean exportExceptionHandlerMBean;
 
 	@Autowired
@@ -36,6 +40,10 @@ public class TestSpaceMirrorFactory {
 
 	public void setExportExceptionHandlerMBean(boolean exportExceptionHandlerMBean) {
 		this.exportExceptionHandlerMBean = exportExceptionHandlerMBean;
+	}
+
+	public void setNextNumberOfInstances(Integer nextNumberOfInstances) {
+		this.nextNumberOfInstances.set(nextNumberOfInstances);
 	}
 
 	public SpaceDataSource createSpaceDataSource() {
@@ -50,6 +58,9 @@ public class TestSpaceMirrorFactory {
 		YmerFactory ymerFactory = new YmerFactory(mongoDbFactory, createMongoConverter(), getDefinitions());
 		ymerFactory.setExportExceptionHandlerMBean(exportExceptionHandlerMBean);
 		ymerFactory.setPlugins(Collections.singleton(new TestProcessor.TestPlugin()));
+		ymerFactory.withProperties(configurer -> {
+			configurer.nextNumberOfInstances(() -> Optional.ofNullable(nextNumberOfInstances.get()));
+		});
 		return ymerFactory.createSpaceSynchronizationEndpoint();
 	}
 

--- a/ymer/src/test/java/com/avanza/ymer/util/GigaSpacesInstanceIdUtilTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/util/GigaSpacesInstanceIdUtilTest.java
@@ -20,15 +20,22 @@ import static org.hamcrest.Matchers.equalTo;
 
 import org.junit.Test;
 
+import com.avanza.ymer.TestSpaceObject;
+
 public class GigaSpacesInstanceIdUtilTest {
 
 	@Test
-	public void shouldExtractInstanceIdFromSpaceName() {
-		String spaceName = "qaSpace_container2_1:qaSpace";
+	public void shouldCalculateInstanceId() {
+		TestSpaceObject spaceObject = new TestSpaceObject("testId", "testMessage");
+		Object routingKey = spaceObject.getId();
 
-		int instanceId = GigaSpacesInstanceIdUtil.extractInstanceIdFromSpaceName(spaceName).orElseThrow();
+		int instanceId_1_partitions = GigaSpacesInstanceIdUtil.getInstanceId(routingKey, 1);
+		int instanceId_4_partitions = GigaSpacesInstanceIdUtil.getInstanceId(routingKey, 4);
+		int instanceId_6_partitions = GigaSpacesInstanceIdUtil.getInstanceId(routingKey, 6);
 
-		assertThat(instanceId, equalTo(2));
+		assertThat(instanceId_1_partitions, equalTo(1));
+		assertThat(instanceId_4_partitions, equalTo(4));
+		assertThat(instanceId_6_partitions, equalTo(2));
 	}
 
  }


### PR DESCRIPTION
* Next number of instances will now be calculated when configured.
  This is done in order to prepare for scaling out to a different amount of instances without having a slow startup.
* In order to store different instanceIds depending on the amount of instances, `_instanceId` field now has a suffix for the amount of instances (e.g. `_instanceId_4`).
* Adds support for reloadable properties (currently only contains next number of instances)
* Next number of instances will be written by mirror when:
-- `PersistedInstanceIdRecalculationService` is called
--Writing new/changing documents

* `PersistedInstanceIdRecalculationService` will now only recalculate objects where `_instanceId` isn't already saved for the current number of partitions. Re-running the job should be much faster than before.
* The name of the created index is no longer used and the default name is used.