### PR TITLE
TP-945: Log object class name on exception

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectWriter.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectWriter.java
@@ -15,6 +15,8 @@
  */
 package com.avanza.ymer;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import com.gigaspaces.sync.DataSyncOperation;
 import com.gigaspaces.sync.DataSyncOperationType;
 import com.gigaspaces.sync.OperationsBatchData;
@@ -168,8 +170,10 @@ final class MirroredObjectWriter {
 
 		private void onException(final Exception exception) {
 			mirror.onMirrorException(exception, operation, objects);
+			Map<String, List<Object>> objectsPerType = Stream.of(this.objects)
+					.collect(Collectors.groupingBy(o -> o.getClass().getSimpleName()));
 			exceptionHandler.handleException(exception,
-					"Operation: " + operation + ", objects: " + Arrays.toString(objects));
+					"Operation: " + operation + ", objects: " + objectsPerType);
 		}
 
 		protected abstract void execute(DBObject... dbOBject);

--- a/ymer/src/test/java/com/avanza/ymer/FakeDocumentWriteExceptionHandler.java
+++ b/ymer/src/test/java/com/avanza/ymer/FakeDocumentWriteExceptionHandler.java
@@ -18,6 +18,7 @@ package com.avanza.ymer;
 public class FakeDocumentWriteExceptionHandler implements DocumentWriteExceptionHandler {
 
 	private final RuntimeException exceptionToThrow;
+	private String lastOperationDescription;
 
 	/**
 	 * Constructs a DocumentWriteExceptionHandler that does nothing.
@@ -36,9 +37,13 @@ public class FakeDocumentWriteExceptionHandler implements DocumentWriteException
 	
 	@Override
 	public void handleException(Exception exception, String operationDescription) {
+		this.lastOperationDescription = operationDescription;
 		if (exceptionToThrow != null) {
 			throw exceptionToThrow;
 		}
 	}
 
+	public String getLastOperationDescription() {
+		return lastOperationDescription;
+	}
 }

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertNotNull;
 
 public class MirroredObjectWriterTest {
 
+	private final FakeDocumentWriteExceptionHandler exceptionHandler = new FakeDocumentWriteExceptionHandler();
 	private MirroredObjectWriter mirroredObjectWriter;
 	private DocumentConverter documentConverter;
 	private DocumentDb documentDb;
@@ -60,7 +61,7 @@ public class MirroredObjectWriterTest {
 		documentDb = FakeDocumentDb.create();
 		mirrorExceptionSpy = new MirrorExceptionSpy();
 		mirror = new SpaceMirrorContext(mirroredObjects, documentConverter, documentDb, mirrorExceptionSpy, Plugins.empty(), 1);
-		mirroredObjectWriter = new MirroredObjectWriter(mirror, new FakeDocumentWriteExceptionHandler());
+		mirroredObjectWriter = new MirroredObjectWriter(mirror, exceptionHandler);
 	}
 
 	@Test
@@ -183,7 +184,7 @@ public class MirroredObjectWriterTest {
 		documentDb = throwsOnUpdateDocumentDb();
 		mirrorExceptionSpy = new MirrorExceptionSpy();
 		mirror = new SpaceMirrorContext(mirroredObjects, documentConverter, documentDb, mirrorExceptionSpy, Plugins.empty(), 1);
-		mirroredObjectWriter = new MirroredObjectWriter(mirror, new FakeDocumentWriteExceptionHandler());
+		mirroredObjectWriter = new MirroredObjectWriter(mirror, exceptionHandler);
 
 		TestSpaceObject item1 = new TestSpaceObject("1", "hello");
 		FakeBulkItem bulkItem = new FakeBulkItem(item1, DataSyncOperationType.UPDATE);
@@ -191,6 +192,10 @@ public class MirroredObjectWriterTest {
 
 		assertNotNull(mirrorExceptionSpy.lastException);
 		assertEquals(RuntimeException.class, mirrorExceptionSpy.lastException.getClass());
+		assertEquals(
+				"Operation: UPDATE, objects: {TestSpaceObject=[TestSpaceObject [id=1, message=hello]]}",
+				exceptionHandler.getLastOperationDescription()
+		);
 	}
 
 	@Test(expected=TransientDocumentWriteException.class)
@@ -231,7 +236,7 @@ public class MirroredObjectWriterTest {
 		});
 		mirrorExceptionSpy = new MirrorExceptionSpy();
 		mirror = new SpaceMirrorContext(mirroredObjects, documentConverter, documentDb, mirrorExceptionSpy, Plugins.empty(), 1);
-		mirroredObjectWriter = new MirroredObjectWriter(mirror, new FakeDocumentWriteExceptionHandler());
+		mirroredObjectWriter = new MirroredObjectWriter(mirror, exceptionHandler);
 
 		TestSpaceObject item1 = new TestSpaceObject("1", "hello");
 		FakeBulkItem bulkItem = new FakeBulkItem(item1, DataSyncOperationType.UPDATE);
@@ -239,6 +244,10 @@ public class MirroredObjectWriterTest {
 
 		assertNotNull(mirrorExceptionSpy.lastException);
 		assertEquals(RuntimeException.class, mirrorExceptionSpy.lastException.getClass());
+		assertEquals(
+				"Operation: UPDATE, objects: {TestSpaceObject=[TestSpaceObject [id=1, message=hello]]}",
+				exceptionHandler.getLastOperationDescription()
+		);
 	}
 
 	@Test


### PR DESCRIPTION
* Adds explicit logging of the class name of failed mongodb document operations.
* The intention is that this will simplify troubleshooting when handling classes that do not by themselves write their class names as part of their `.toString()`-output.