### PR TITLE
TP-820: Fix bug in `collectionNeedsCalculation`

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdCalculationService.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdCalculationService.java
@@ -18,7 +18,6 @@ package com.avanza.ymer;
 import static com.avanza.ymer.MirroredObject.DOCUMENT_INSTANCE_ID_PREFIX;
 import static com.avanza.ymer.MirroredObject.DOCUMENT_ROUTING_KEY;
 import static com.avanza.ymer.PersistedInstanceIdUtil.getInstanceIdFieldName;
-import static com.avanza.ymer.PersistedInstanceIdUtil.isIndexForAnyNumberOfPartitionsIn;
 import static com.avanza.ymer.PersistedInstanceIdUtil.isIndexForNumberOfPartitions;
 import static com.avanza.ymer.util.GigaSpacesInstanceIdUtil.NUMBER_OF_PARTITIONS_SYSTEM_PROPERTY;
 import static com.avanza.ymer.util.GigaSpacesInstanceIdUtil.getInstanceId;
@@ -87,10 +86,9 @@ public class PersistedInstanceIdCalculationService implements PersistedInstanceI
 			return false;
 		}
 		try {
-			Set<Integer> numberOfPartitionsSet = getNumberOfPartitionsToCalculate();
-			DocumentCollection collection = spaceMirror.getDocumentDb().getCollection(collectionName);
-			return collection.getIndexes()
-					.noneMatch(isIndexForAnyNumberOfPartitionsIn(numberOfPartitionsSet));
+			List<IndexInfo> indices = spaceMirror.getDocumentDb().getCollection(collectionName).getIndexes().collect(toList());
+			return getNumberOfPartitionsToCalculate().stream()
+					.anyMatch(numPartitions -> indices.stream().noneMatch(isIndexForNumberOfPartitions(numPartitions)));
 		} catch (Exception e) {
 			log.warn("Could not determine whether persisted instance id should be calculated for collection [{}]", collectionName, e);
 			return false;

--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdUtil.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdUtil.java
@@ -18,7 +18,6 @@ package com.avanza.ymer;
 import static com.avanza.ymer.MirroredObject.DOCUMENT_INSTANCE_ID_PREFIX;
 
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
 
 import org.springframework.data.mongodb.core.index.IndexInfo;
@@ -26,10 +25,6 @@ import org.springframework.data.mongodb.core.index.IndexInfo;
 final class PersistedInstanceIdUtil {
 
 	private PersistedInstanceIdUtil() {
-	}
-
-	public static Predicate<IndexInfo> isIndexForAnyNumberOfPartitionsIn(Set<Integer> numberOfPartitions) {
-		return indexInfo -> numberOfPartitions.stream().anyMatch(fieldName -> isIndexForNumberOfPartitions(fieldName).test(indexInfo));
 	}
 
 	public static Predicate<IndexInfo> isIndexForNumberOfPartitions(int numberOfPartitions) {

--- a/ymer/src/test/java/com/avanza/ymer/PersistedInstanceIdCalculationServiceTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/PersistedInstanceIdCalculationServiceTest.java
@@ -16,6 +16,7 @@
 package com.avanza.ymer;
 
 import static com.avanza.ymer.MirroredObject.DOCUMENT_ROUTING_KEY;
+import static com.avanza.ymer.PersistedInstanceIdUtil.getInstanceIdFieldName;
 import static com.avanza.ymer.TestSpaceMirrorObjectDefinitions.TEST_SPACE_OBJECT;
 import static com.avanza.ymer.util.GigaSpacesInstanceIdUtil.getInstanceId;
 import static com.j_spaces.core.Constants.Mirror.FULL_MIRROR_SERVICE_CLUSTER_PARTITIONS_COUNT;
@@ -166,15 +167,32 @@ public class PersistedInstanceIdCalculationServiceTest {
 	@Test
 	public void testCollectionNeedsCalculation() throws Exception {
 		int numberOfInstances = 1;
+		var spaceMirrorFactory = new TestSpaceMirrorFactory(mirrorEnvironment.getMongoTemplate().getMongoDbFactory());
 		execute(() -> {
-			try (YmerSpaceSynchronizationEndpoint endpoint = createSpaceSynchronizationEndpoint()) {
+			try (YmerSpaceSynchronizationEndpoint endpoint = (YmerSpaceSynchronizationEndpoint) spaceMirrorFactory.createSpaceSynchronizationEndpoint()) {
 				PersistedInstanceIdCalculationService target = endpoint.getPersistedInstanceIdCalculationService();
-				assertTrue(target.collectionNeedsCalculation(TEST_SPACE_OBJECT.collectionName()));
+				assertTrue("In the initial state, collection should need to be calculated",
+						target.collectionNeedsCalculation(TEST_SPACE_OBJECT.collectionName()));
 
 				target.calculatePersistedInstanceId(TEST_SPACE_OBJECT.collectionName());
-				verifyCollectionIsCalculatedFor(numberOfInstances);
+				assertFalse("The collection should now be calculated for [1] number of instances",
+						target.collectionNeedsCalculation(TEST_SPACE_OBJECT.collectionName()));
 
-				assertFalse(target.collectionNeedsCalculation(TEST_SPACE_OBJECT.collectionName()));
+				spaceMirrorFactory.setNextNumberOfInstances(2);
+				assertTrue("Should need recalculation when next number of instances is set",
+						target.collectionNeedsCalculation(TEST_SPACE_OBJECT.collectionName()));
+
+				target.calculatePersistedInstanceId(TEST_SPACE_OBJECT.collectionName());
+				assertFalse("The collection should now be calculated for [1, 2] number of instances",
+						target.collectionNeedsCalculation(TEST_SPACE_OBJECT.collectionName()));
+
+				spaceMirrorFactory.setNextNumberOfInstances(3);
+				assertTrue("Should need recalculation again when next number of instances is updated to a different value",
+						target.collectionNeedsCalculation(TEST_SPACE_OBJECT.collectionName()));
+
+				spaceMirrorFactory.setNextNumberOfInstances(null);
+				assertFalse("Should not need recalculation if next number of instances property is removed",
+						target.collectionNeedsCalculation(TEST_SPACE_OBJECT.collectionName()));
 			}
 		}, new SystemProperties("cluster.partitions", String.valueOf(numberOfInstances)));
 	}
@@ -197,7 +215,7 @@ public class PersistedInstanceIdCalculationServiceTest {
 
 	private void verifyCollectionIsCalculatedFor(int numberOfInstances) {
 		MongoDocumentCollection mongoDocumentCollection = new MongoDocumentCollection(collection);
-		String fieldName = PersistedInstanceIdUtil.getInstanceIdFieldName(numberOfInstances);
+		String fieldName = getInstanceIdFieldName(numberOfInstances);
 		mongoDocumentCollection.findAll()
 				.forEach(document ->
 								 assertThat(document.getInteger(fieldName), is(getInstanceId(document.get(DOCUMENT_ROUTING_KEY), numberOfInstances)))
@@ -207,7 +225,7 @@ public class PersistedInstanceIdCalculationServiceTest {
 
 	private void verifyCollectionIsNotCalculatedFor(int numberOfInstances) {
 		MongoDocumentCollection mongoDocumentCollection = new MongoDocumentCollection(collection);
-		String fieldName = PersistedInstanceIdUtil.getInstanceIdFieldName(numberOfInstances);
+		String fieldName = getInstanceIdFieldName(numberOfInstances);
 		mongoDocumentCollection.findAll()
 				.forEach(document ->
 						assertThat("Should not contain " + fieldName, document.containsKey(fieldName), is(false))


### PR DESCRIPTION
* This method did not properly check if calculation is needed when nextNumberOfInstances is used. This method only worked when no of the number of partitions to calculate were calculated, but we want to do a calculation when any of them are missing (such as adding a new `nextNumberOfInstances` when current number of instances is already calculated).

Found during review of [another issue](https://github.com/AvanzaBank/ymer/pull/67).