### PR TITLE
TP-937: Do not fail application context if `initializeStatistics()` fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 		<junit-jupiter.version>5.7.2</junit-jupiter.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<mockito.version>3.12.4</mockito.version>
-		<gs-test.version>1.0.1</gs-test.version>
+		<gs-test.version>1.0.2</gs-test.version>
 		<mongo-java-driver.version>3.8.2</mongo-java-driver.version>
 		<testcontainers.version>1.16.2</testcontainers.version>
 		<awaitility.version>4.1.0</awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
 		<junit-jupiter.version>5.7.2</junit-jupiter.version>
 		<hamcrest.version>2.2</hamcrest.version>
 		<mockito.version>3.12.4</mockito.version>
-		<gs-test.version>1.0.2</gs-test.version>
+		<gs-test.version>1.0.3</gs-test.version>
 		<mongo-java-driver.version>3.8.2</mongo-java-driver.version>
 		<testcontainers.version>1.16.2</testcontainers.version>
 		<awaitility.version>4.1.0</awaitility.version>

--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdCalculationService.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdCalculationService.java
@@ -89,7 +89,13 @@ public class PersistedInstanceIdCalculationService implements PersistedInstanceI
 
 	// Initializes readyForNumberOfPartitions for collections that are already calculated
 	void initializeStatistics() {
-		Set<Integer> numberOfPartitionsToCalculate = getNumberOfPartitionsToCalculate();
+		Set<Integer> numberOfPartitionsToCalculate;
+		try {
+			numberOfPartitionsToCalculate = getNumberOfPartitionsToCalculate();
+		} catch (Exception e) {
+			log.warn("Could not get number of partitions to calculate, unable to initialize persisted instance id statistics", e);
+			return;
+		}
 		getCollectionsWithPersistInstanceIdEnabled().forEach(collectionName -> {
 			try {
 				PersistedInstanceIdStatistics statistics = getStatisticsForCollection(collectionName);

--- a/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
+++ b/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
@@ -92,11 +92,13 @@ final class YmerSpaceSynchronizationEndpoint extends SpaceSynchronizationEndpoin
 			GigaSpacesInstanceIdUtil.getNumberOfPartitionsFromSpaceProperties(applicationContext).ifPresent(
 					numberOfPartitions -> currentNumberOfPartitions = numberOfPartitions
 			);
-			if (currentNumberOfPartitions == null) {
-				log.warn("Could not determine current number of partitions. Will not be able to persist current instance id");
+			if (spaceMirror.getMirroredDocuments().stream().anyMatch(MirroredObject::persistInstanceId)) {
+				if (currentNumberOfPartitions == null) {
+					log.warn("Could not determine current number of partitions. Will not be able to persist current instance id");
+				}
+				persistedInstanceIdCalculationService.initializeStatistics();
+				schedulePersistedIdCalculationIfNecessary();
 			}
-			persistedInstanceIdCalculationService.initializeStatistics();
-			schedulePersistedIdCalculationIfNecessary();
 		}
 	}
 

--- a/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorFactory.java
+++ b/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorFactory.java
@@ -65,7 +65,7 @@ public class TestSpaceMirrorFactory {
 	}
 
 	private Collection<MirroredObjectDefinition<?>> getDefinitions() {
-		return new TestSpaceMirrorObjectDefinitions().getDefinitions();
+		return TestSpaceMirrorObjectDefinitions.getDefinitions();
 	}
 
 	private MongoConverter createMongoConverter() {

--- a/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
+++ b/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
@@ -21,7 +21,10 @@ import java.util.Collection;
 import com.avanza.ymer.YmerInitialLoadIntegrationTest.TestSpaceObjectV1Patch;
 import com.avanza.ymer.YmerInitialLoadIntegrationTest.TestSpaceObjectV2Patch;
 
-public class TestSpaceMirrorObjectDefinitions  {
+public class TestSpaceMirrorObjectDefinitions {
+
+	private TestSpaceMirrorObjectDefinitions() {
+	}
 
 	public static final MirroredObjectDefinition<TestSpaceObject> TEST_SPACE_OBJECT =
 			MirroredObjectDefinition.create(TestSpaceObject.class)
@@ -41,7 +44,7 @@ public class TestSpaceMirrorObjectDefinitions  {
 			MirroredObjectDefinition.create(TestSpaceThirdObject.class)
 					.documentPatches(new TestSpaceThirdObject.TestSpaceThirdObjectPatchV1());
 
-	public Collection<MirroredObjectDefinition<?>> getDefinitions() {
+	public static Collection<MirroredObjectDefinition<?>> getDefinitions() {
 		return Arrays.asList(
 				TEST_SPACE_OBJECT,
 				TEST_SPACE_OTHER_OBJECT,

--- a/ymer/src/test/java/com/avanza/ymer/YmerMirrorNoClusterPropertiesIntegrationTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/YmerMirrorNoClusterPropertiesIntegrationTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.MongoDbFactory;
+
+import com.avanza.gs.test.PuConfigurers;
+import com.avanza.gs.test.RunningPu;
+import com.gigaspaces.sync.SpaceSynchronizationEndpoint;
+
+/**
+ * This verifies that the application context can be started without cluster properties being defined.
+ * Such a setup might be used in test scenarios, but is not expected in a real runtime.
+ */
+public class YmerMirrorNoClusterPropertiesIntegrationTest {
+
+	@ClassRule
+	public static final MirrorEnvironment mirrorEnv = new MirrorEnvironment();
+
+	@Test
+	public void shouldStartMirrorWhenInstanceIdPersistingIsEnabled() throws Exception {
+		try (RunningPu mirrorPu = PuConfigurers.mirrorPu(ApplicationConfigWithInstanceIdPersisting.class).configure()) {
+			// This test should log a lot of warnings, but still start the application context
+			mirrorPu.start();
+		}
+	}
+
+	@Test
+	public void shouldStartMirrorWhenInstanceIdPersistingIsDisabled() throws Exception {
+		try (RunningPu mirrorPu = PuConfigurers.mirrorPu(ApplicationConfigWithoutInstanceIdPersisting.class).configure()) {
+			// This test should start the application context without warnings about current number of instances
+			mirrorPu.start();
+		}
+	}
+
+	@Configuration
+	static class TestConfigBase {
+		@Bean
+		public YmerFactory ymerFactory(Collection<MirroredObjectDefinition<?>> testDefinitions) {
+			MongoDbFactory mongoDbFactory = mirrorEnv.getMongoTemplate().getMongoDbFactory();
+			return new YmerFactory(
+					mongoDbFactory,
+					new TestSpaceMongoConverterFactory(mongoDbFactory).createMongoConverter(),
+					testDefinitions
+			);
+		}
+
+		@Bean
+		public SpaceSynchronizationEndpoint spaceSynchronizationEndpoint(YmerFactory ymerFactory) {
+			return ymerFactory.createSpaceSynchronizationEndpoint();
+		}
+	}
+
+	@Configuration
+	@Import(TestConfigBase.class)
+	static class ApplicationConfigWithInstanceIdPersisting {
+		@Bean
+		public Collection<MirroredObjectDefinition<?>> testDefinitions() {
+			return TestSpaceMirrorObjectDefinitions.getDefinitions();
+		}
+	}
+
+	@Configuration
+	@Import(TestConfigBase.class)
+	static class ApplicationConfigWithoutInstanceIdPersisting {
+		@Bean
+		public Collection<MirroredObjectDefinition<?>> testDefinitions() {
+			return List.of(TestSpaceMirrorObjectDefinitions.TEST_SPACE_THIRD_OBJECT);
+		}
+	}
+
+}


### PR DESCRIPTION
* Also, to avoid unnecessary warning logs in tests, only execute `initializeStatistics()` if persisting of instance id is enabled for any mirrored object.
* This is also applied to another warning log about current number of partitions and scheduling of persisted instance id calculation.