### PR TITLE
TP-938: Align configuration format to other config in `MirroredObjectDefinition`

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
@@ -61,7 +61,7 @@ final class MirroredObject<T> {
         this.writeBackPatchedDocuments = override.writeBackPatchedDocuments(definition);
         this.loadDocumentsRouted = override.loadDocumentsRouted(definition);
 
-		PersistInstanceIdDefinition<?> persistInstanceId = override.persistInstanceId(definition);
+		PersistInstanceIdDefinition persistInstanceId = override.persistInstanceId(definition);
         this.persistInstanceId = persistInstanceId.isEnabled();
 		this.triggerInstanceIdCalculationOnStartup = persistInstanceId.isTriggerCalculationOnStartup();
 		this.triggerInstanceIdCalculationWithDelay = persistInstanceId.getTriggerCalculationWithDelay();

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinition.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinition.java
@@ -33,6 +33,7 @@ package com.avanza.ymer;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import org.springframework.data.mongodb.MongoCollectionUtils;
 
@@ -52,7 +53,7 @@ public final class MirroredObjectDefinition<T> {
 	private boolean excludeFromInitialLoad = false;
 	private boolean writeBackPatchedDocuments = true;
 	private boolean loadDocumentsRouted = false;
-	private final PersistInstanceIdDefinition<T> persistInstanceId = new PersistInstanceIdDefinition<>(this);
+	private final PersistInstanceIdDefinition persistInstanceId = new PersistInstanceIdDefinition();
 	private boolean keepPersistent = false;
 	private TemplateFactory customInitialLoadTemplateFactory;
 	private ReadPreference readPreference;
@@ -149,13 +150,31 @@ public final class MirroredObjectDefinition<T> {
 	 * This can increase load speed, but requires all persisted partition numbers to be recalculated
 	 * when the number of partitions change.
 	 *
-	 * This will enable persisting of instance id with default settings.
+	 * For more properties related to instance id persisting, see {@link #persistInstanceId(Consumer)}
 	 */
-	public PersistInstanceIdDefinition<T> persistInstanceId() {
-		return persistInstanceId.enableWithDefaults();
+	public MirroredObjectDefinition<T> persistInstanceId(boolean enabled) {
+		persistInstanceId.enabled(enabled);
+		return this;
 	}
 
-	PersistInstanceIdDefinition<T> getPersistInstanceId() {
+	/**
+	 * Configuration relating to persisting the instance id.
+	 * This method accepts a configurer where more detailed configuration is available.
+	 * This configuration can be used in the following manner:
+	 *
+	 * <pre>{@code
+	 *   .persistInstanceId(configurer -> configurer
+	 *       .enabled(true)
+	 *       .triggerCalculationWithDelay(Duration.ofMinutes(60))
+	 *   )
+	 * }</pre>
+	 */
+	public MirroredObjectDefinition<T> persistInstanceId(Consumer<PersistInstanceIdDefinition> configurer) {
+		configurer.accept(persistInstanceId);
+		return this;
+	}
+
+	PersistInstanceIdDefinition getPersistInstanceId() {
 		return persistInstanceId;
 	}
 

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinitionsOverride.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectDefinitionsOverride.java
@@ -28,7 +28,7 @@ public interface MirroredObjectDefinitionsOverride {
     boolean excludeFromInitialLoad(MirroredObjectDefinition<?> definition);
     boolean writeBackPatchedDocuments(MirroredObjectDefinition<?> definition);
     boolean loadDocumentsRouted(MirroredObjectDefinition<?> definition);
-    PersistInstanceIdDefinition<?> persistInstanceId(MirroredObjectDefinition<?> definition);
+    PersistInstanceIdDefinition persistInstanceId(MirroredObjectDefinition<?> definition);
 
     static MirroredObjectDefinitionsOverride noOverride() {
         return new MirroredObjectDefinitionsOverrideNone();
@@ -55,7 +55,7 @@ public interface MirroredObjectDefinitionsOverride {
         }
 
         @Override
-        public PersistInstanceIdDefinition<?> persistInstanceId(MirroredObjectDefinition<?> definition) {
+        public PersistInstanceIdDefinition persistInstanceId(MirroredObjectDefinition<?> definition) {
             return definition.getPersistInstanceId();
         }
     }
@@ -80,8 +80,8 @@ public interface MirroredObjectDefinitionsOverride {
         }
 
         @Override
-        public PersistInstanceIdDefinition<?> persistInstanceId(MirroredObjectDefinition<?> definition) {
-            PersistInstanceIdDefinition<?> persistInstanceId = PersistInstanceIdDefinition.from(definition.getPersistInstanceId());
+        public PersistInstanceIdDefinition persistInstanceId(MirroredObjectDefinition<?> definition) {
+            PersistInstanceIdDefinition persistInstanceId = PersistInstanceIdDefinition.from(definition.getPersistInstanceId());
             getProperty(definition, "persistInstanceId").ifPresent(persistInstanceId::enabled);
             getProperty(definition, "triggerInstanceIdCalculationOnStartup").ifPresent(persistInstanceId::triggerCalculationOnStartup);
             getIntProperty(definition, "triggerInstanceIdCalculationWithDelay")

--- a/ymer/src/main/java/com/avanza/ymer/PersistInstanceIdDefinition.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistInstanceIdDefinition.java
@@ -17,34 +17,25 @@ package com.avanza.ymer;
 
 import java.time.Duration;
 
-public final class PersistInstanceIdDefinition<T> {
+public final class PersistInstanceIdDefinition {
 
 	private static final Duration DEFAULT_DELAY = Duration.ofHours(1);
 
-	private final MirroredObjectDefinition<T> parent;
-	private boolean enabled;
-	private boolean triggerCalculationOnStartup;
+	private boolean enabled = false;
+	private boolean triggerCalculationOnStartup = true;
 	private Duration triggerCalculationWithDelay = DEFAULT_DELAY;
 
-	PersistInstanceIdDefinition(MirroredObjectDefinition<T> parent) {
-		this.parent = parent;
-	}
-
-	static <T> PersistInstanceIdDefinition<T> from(PersistInstanceIdDefinition<T> from) {
-		return new PersistInstanceIdDefinition<>(from.getParent())
+	static PersistInstanceIdDefinition from(PersistInstanceIdDefinition from) {
+		return new PersistInstanceIdDefinition()
 				.enabled(from.enabled)
 				.triggerCalculationOnStartup(from.triggerCalculationOnStartup)
 				.triggerCalculationWithDelay(from.triggerCalculationWithDelay);
 	}
 
-	public PersistInstanceIdDefinition<T> enableWithDefaults() {
-		return enabled(true).triggerCalculationOnStartup(true);
-	}
-
 	/**
 	 * Whether to enable persisting the instance id for each document.
 	 */
-	public PersistInstanceIdDefinition<T> enabled(boolean enabled) {
+	public PersistInstanceIdDefinition enabled(boolean enabled) {
 		this.enabled = enabled;
 		return this;
 	}
@@ -59,7 +50,7 @@ public final class PersistInstanceIdDefinition<T> {
 	 * Automatically starting this job requires {@link YmerSpaceSynchronizationEndpoint} to be handled
 	 * as a Spring bean.
 	 */
-	public PersistInstanceIdDefinition<T> triggerCalculationOnStartup(boolean triggerCalculationOnStartup) {
+	public PersistInstanceIdDefinition triggerCalculationOnStartup(boolean triggerCalculationOnStartup) {
 		this.triggerCalculationOnStartup = triggerCalculationOnStartup;
 		return this;
 	}
@@ -69,23 +60,9 @@ public final class PersistInstanceIdDefinition<T> {
 	 * This is done to reduce load on database during initial load of data.
 	 * This property only has an effect when {@code triggerCalculationOnStartup} is enabled.
 	 */
-	public PersistInstanceIdDefinition<T> triggerCalculationWithDelay(Duration triggerCalculationWithDelay) {
+	public PersistInstanceIdDefinition triggerCalculationWithDelay(Duration triggerCalculationWithDelay) {
 		this.triggerCalculationWithDelay = triggerCalculationWithDelay;
 		return this;
-	}
-
-	/**
-	 * Return the {@code MirroredObjectDefinition} when done configuring the {@code PersistInstanceIdDefinition}.
-	 * This is useful for method chaining.
-	 *
-	 * @return the MirroredObjectDefinition for further customizations
-	 */
-	public MirroredObjectDefinition<T> and() {
-		return getParent();
-	}
-
-	private MirroredObjectDefinition<T> getParent() {
-		return parent;
 	}
 
 	boolean isEnabled() {

--- a/ymer/src/main/java/com/avanza/ymer/ReloadableYmerProperties.java
+++ b/ymer/src/main/java/com/avanza/ymer/ReloadableYmerProperties.java
@@ -45,7 +45,7 @@ public final class ReloadableYmerProperties {
 
 		/**
 		 * Sets a supplier returning the coming amount of partitions planned for the space after restart.
-		 * This is designed to be used in combination with {@link MirroredObjectDefinition#persistInstanceId()}.
+		 * This is designed to be used in combination with {@link MirroredObjectDefinition#persistInstanceId(boolean)}.
 		 * <p>
 		 * When writing the instance ID field, both the instance ID using the current number of partitions and the next
 		 * number of partitions will be set to the document. It will also be used when calling {@link PersistedInstanceIdCalculationService}.

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectLoaderTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectLoaderTest.java
@@ -94,8 +94,7 @@ public class MirroredObjectLoaderTest {
 	@Test
 	public void loadsAllObjectsRoutedToCurrentPartitionByPersistedInstanceId() {
 		MirroredObject<FakeSpaceObject> mirroredObject = MirroredObjectDefinition.create(FakeSpaceObject.class)
-				.persistInstanceId()
-				.and()
+				.persistInstanceId(true)
 				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 
 		String documentInstanceIdField = PersistedInstanceIdUtil.getInstanceIdFieldName(contextProperties.getPartitionCount());

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectTest.java
@@ -345,8 +345,7 @@ public class MirroredObjectTest {
 	@Test
 	public void setsInstanceIdAndRoutingKeyForPersistInstanceId() throws Exception {
 		MirroredObject<MirroredType> document = MirroredObjectDefinition.create(MirroredType.class)
-				.persistInstanceId()
-				.and()
+				.persistInstanceId(true)
 				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 		Document dbObject = new Document();
 
@@ -360,8 +359,7 @@ public class MirroredObjectTest {
 	@Test
 	public void setsNextInstanceIdAndRoutingKeyForPersistInstanceId() throws Exception {
 		MirroredObject<MirroredType> document = MirroredObjectDefinition.create(MirroredType.class)
-				.persistInstanceId()
-				.and()
+				.persistInstanceId(true)
 				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 		Document dbObject = new Document();
 
@@ -376,8 +374,7 @@ public class MirroredObjectTest {
 	@Test
 	public void doesNotSetInstanceIdWhenNull() throws Exception {
 		MirroredObject<MirroredType> document = MirroredObjectDefinition.create(MirroredType.class)
-				.persistInstanceId()
-				.and()
+				.persistInstanceId(true)
 				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 		int routingKey = 23;
 
@@ -391,8 +388,7 @@ public class MirroredObjectTest {
 	@Test
 	public void willAlwaysCalculateNextNumberOfPartitionsIfSet() throws Exception {
 		MirroredObject<MirroredType> document = MirroredObjectDefinition.create(MirroredType.class)
-				.persistInstanceId()
-				.and()
+				.persistInstanceId(true)
 				.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 		Document dbObject = new Document();
 
@@ -407,8 +403,7 @@ public class MirroredObjectTest {
 		MirroredObjectDefinition<RoutedType> definition = MirroredObjectDefinition.create(RoutedType.class)
 				.loadDocumentsRouted(true)
 				.writeBackPatchedDocuments(true)
-				.persistInstanceId()
-				.and()
+				.persistInstanceId(true)
 				.excludeFromInitialLoad(true);
 
 		assertTrue(definition.buildMirroredDocument(fromSystemProperties()).loadDocumentsRouted());

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
@@ -62,8 +62,7 @@ public class MirroredObjectWriterTest {
 		anotherMirroredDocument =
 				MirroredObjectDefinition.create(TestSpaceOtherObject.class)
 										.keepPersistent(true)
-										.persistInstanceId()
-										.and()
+										.persistInstanceId(true)
 										.documentPatches(patches2)
 										.buildMirroredDocument(MirroredObjectDefinitionsOverride.noOverride());
 		DocumentPatch[] patches1 = {};

--- a/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
+++ b/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
@@ -29,15 +29,16 @@ public class TestSpaceMirrorObjectDefinitions {
 	public static final MirroredObjectDefinition<TestSpaceObject> TEST_SPACE_OBJECT =
 			MirroredObjectDefinition.create(TestSpaceObject.class)
 					.loadDocumentsRouted(true)
-					.persistInstanceId()
-					.and()
+					.persistInstanceId(true)
 					.documentPatches(new TestSpaceObjectV1Patch(), new TestSpaceObjectV2Patch());
 
 	public static final MirroredObjectDefinition<TestSpaceOtherObject> TEST_SPACE_OTHER_OBJECT =
 			MirroredObjectDefinition.create(TestSpaceOtherObject.class)
 					.writeBackPatchedDocuments(false)
-					.persistInstanceId()
-					.and()
+					.persistInstanceId(configurer -> configurer
+							.enabled(true)
+							.triggerCalculationOnStartup(false)
+					)
 					.documentPatches(new TestSpaceObjectV1Patch());
 
 	public static final MirroredObjectDefinition<TestSpaceThirdObject> TEST_SPACE_THIRD_OBJECT =


### PR DESCRIPTION
* No functionality is changed, this only changes the configuration code
* The current format does not align well with the other configuration available
* In particular, a `persistInstanceId(boolean enabled)` method will make this more like the others
* More detailed properties can be accessed through a method accepting a `Consumer`

An example of the new config format can be seen in [TestSpaceMirrorObjectDefinitions](https://github.com/AvanzaBank/ymer/blob/6a902337f2a049e7fec79ef60bb7c4a8e666922d/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java)