### PR TITLE
TP-939: Small log adjustments to clarify which loading method is used

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdCalculationService.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdCalculationService.java
@@ -268,12 +268,13 @@ public class PersistedInstanceIdCalculationService implements PersistedInstanceI
 			boolean indexExists = collection.getIndexes()
 					.anyMatch(isIndexForNumberOfPartitions(numberOfPartitions));
 			if (indexExists) {
-				log.info("Step 3/3\tIndex for field [{}] does not need to be created because it already exists", fieldName);
+				log.info("Step 3/3\tIndex for field [{}] in collection {} does not need to be created because it already exists",
+						fieldName, collectionName);
 			} else {
-				log.info("Step 3/3\tCreating index for field [{}]", fieldName);
+				log.info("Step 3/3\tCreating index for field [{}] in collection {}", fieldName, collectionName);
 				IndexOptions options = new IndexOptions().background(true);
 				collection.createIndex(new Document(fieldName, 1), options);
-				log.info("Step 3/3\tDone creating index");
+				log.info("Step 3/3\tDone creating index for field [{}] in collection {}", fieldName, collectionName);
 			}
 		});
 

--- a/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdCalculationService.java
+++ b/ymer/src/main/java/com/avanza/ymer/PersistedInstanceIdCalculationService.java
@@ -293,14 +293,14 @@ public class PersistedInstanceIdCalculationService implements PersistedInstanceI
 	private Optional<Integer> getNumberOfPartitionsFromSpaceProperties() {
 		return GigaSpacesInstanceIdUtil.getNumberOfPartitionsFromSpaceProperties(applicationContext)
 				.map(peek(numberOfPartitions ->
-								  log.info("Using {} number of partitions (from space property \"{}\")", numberOfPartitions, MIRROR_SERVICE_CLUSTER_PARTITIONS_COUNT)
+						log.debug("Using {} number of partitions (from space property \"{}\")", numberOfPartitions, MIRROR_SERVICE_CLUSTER_PARTITIONS_COUNT)
 				));
 	}
 
 	private Optional<Integer> getNumberOfPartitionsFromSystemProperty() {
 		return GigaSpacesInstanceIdUtil.getNumberOfPartitionsFromSystemProperty()
 				.map(peek(numberOfPartitions ->
-								  log.info("Using {} number of partitions (from system property \"{}\")", numberOfPartitions, NUMBER_OF_PARTITIONS_SYSTEM_PROPERTY)
+						log.debug("Using {} number of partitions (from system property \"{}\")", numberOfPartitions, NUMBER_OF_PARTITIONS_SYSTEM_PROPERTY)
 				));
 	}
 

--- a/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
+++ b/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
@@ -140,7 +140,7 @@ final class YmerSpaceSynchronizationEndpoint extends SpaceSynchronizationEndpoin
 	}
 
 	private void registerMbean(Object object, String name) {
-		log.info("Registering MBean with name {}", name);
+		log.debug("Registering MBean with name {}", name);
 		try {
 			ObjectName objectName = ObjectName.getInstance(name);
 			ManagementFactory.getPlatformMBeanServer().registerMBean(object, objectName);


### PR DESCRIPTION
* Replace `Begin loadAllObjects` log with a log that also displays which loading method is used.
* Add collection being operated on in some calculation job logs