### PR TITLE
Converter registration

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/ConverterConfigurer.java
+++ b/ymer/src/main/java/com/avanza/ymer/ConverterConfigurer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.avanza.ymer;
 
 import org.springframework.core.convert.converter.Converter;

--- a/ymer/src/main/java/com/avanza/ymer/ConverterConfigurer.java
+++ b/ymer/src/main/java/com/avanza/ymer/ConverterConfigurer.java
@@ -1,0 +1,23 @@
+package com.avanza.ymer;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.ConverterFactory;
+import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.data.convert.ConverterBuilder.ConverterAware;
+
+/**
+ * Type-safe registration of type converters.
+ *
+ * @see org.springframework.data.convert.CustomConversions CustomConversions
+ */
+public interface ConverterConfigurer {
+
+	void add(Converter<?, ?>... converters);
+
+	void add(ConverterFactory<?, ?>... converters);
+
+	void add(GenericConverter... converters);
+
+	void add(ConverterAware... converters);
+
+}

--- a/ymer/src/main/java/com/avanza/ymer/ConverterCustomizer.java
+++ b/ymer/src/main/java/com/avanza/ymer/ConverterCustomizer.java
@@ -1,0 +1,7 @@
+package com.avanza.ymer;
+
+public interface ConverterCustomizer {
+
+	void customize(ConverterConfigurer converters);
+
+}

--- a/ymer/src/main/java/com/avanza/ymer/ConverterCustomizer.java
+++ b/ymer/src/main/java/com/avanza/ymer/ConverterCustomizer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.avanza.ymer;
 
 public interface ConverterCustomizer {


### PR DESCRIPTION
### ConverterCustomizer
A type-safe way to configure type converters supported by `CustomConversions`.
Also encapsulates creation of `MongoConverter`.