### PR TITLE
TP-1047: Deep-copy `BasicDBObject` for document-patch compatibility

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/BasicDbObjectCompatibility.java
+++ b/ymer/src/main/java/com/avanza/ymer/BasicDbObjectCompatibility.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import java.util.List;
+import java.util.Map;
+
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+
+/**
+ * Converts fields that have data types such as {@code List} or {@code Map} to
+ * their corresponding {@code DBObject} datatype, to enable compatibility with
+ * old document patches that have not migrated yet from {@code DocumentPatch} to
+ * {@code BsonDocumentPatch}.
+ */
+@SuppressWarnings({ "rawtypes" })
+class BasicDbObjectCompatibility {
+	static BasicDBObject convertToBasicDBObject(Map map) {
+		BasicDBObject dbObject = new BasicDBObject(map);
+		dbObject.replaceAll((k, v) -> convertToDBObject(v));
+		return dbObject;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Object convertToDBObject(Object o) {
+		if (o instanceof Map) {
+			return convertToBasicDBObject((Map) o);
+		} else if (o instanceof List) {
+			BasicDBList list = new BasicDBList();
+			((List) o).forEach(i -> list.add(convertToDBObject(i)));
+			return list;
+		}
+		return o;
+	}
+}

--- a/ymer/src/main/java/com/avanza/ymer/BsonDocumentPatch.java
+++ b/ymer/src/main/java/com/avanza/ymer/BsonDocumentPatch.java
@@ -32,7 +32,13 @@ public interface BsonDocumentPatch {
 	 * Returns the version that this patch applies to. A DocumentPatch only applies
 	 * to a single version. A DocumentPatch is expected to patch the document
 	 * to the next version. <p>
-	 *
+	 * This patch will be applied to all documents whose version is equal or
+	 * lower than this number. After this patch has been applied, the document
+	 * will have its version updated to {@code patchedVersion + 1}. Documents
+	 * that have not had any patches applied, or otherwise are missing the
+	 * version field, will be considered to be at version {@code 1}. Therefore,
+	 * if this is the first patch to apply for a particular document type, set
+	 * this value to {@code 1}.
 	 */
 	int patchedVersion();
 }

--- a/ymer/src/main/java/com/avanza/ymer/DocumentPatch.java
+++ b/ymer/src/main/java/com/avanza/ymer/DocumentPatch.java
@@ -15,6 +15,8 @@
  */
 package com.avanza.ymer;
 
+import static com.avanza.ymer.BasicDbObjectCompatibility.convertToBasicDBObject;
+
 import org.bson.Document;
 
 import com.mongodb.BasicDBObject;
@@ -36,7 +38,7 @@ public interface DocumentPatch extends BsonDocumentPatch {
 	void apply(BasicDBObject dbObject);
 
 	default void apply(Document document) {
-		BasicDBObject dbo = new BasicDBObject(document);
+		BasicDBObject dbo = convertToBasicDBObject(document);
 		apply(dbo);
 		document.putAll(dbo); // Ensures that new properties are added and replaced properties are updated.
 		document.keySet().retainAll(dbo.keySet()); // Ensures that removed properties are deleted.
@@ -46,8 +48,13 @@ public interface DocumentPatch extends BsonDocumentPatch {
 	 * Returns the version that this patch applies to. A DocumentPatch only applies 
 	 * to a single version. A DocumentPatch is expected to patch the document
 	 * to the next version.
-	 *
+	 * This patch will be applied to all documents whose version is equal or
+	 * lower than this number. After this patch has been applied, the document
+	 * will have its version updated to {@code patchedVersion + 1}. Documents
+	 * that have not had any patches applied, or otherwise are missing the
+	 * version field, will be considered to be at version {@code 1}. Therefore,
+	 * if this is the first patch to apply for a particular document type, set
+	 * this value to {@code 1}.
 	 */
 	int patchedVersion();
-	
 }

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectLoader.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectLoader.java
@@ -202,7 +202,7 @@ final class MirroredObjectLoader<T> {
     }
 
     /*
-     * Holds the space representation of a document loaded form an external data source (typically mongo)
+     * Holds the space representation of a document loaded from an external data source (typically mongo)
      * and also an Optional {@link PatchedDocument} which is present if the document was patched during
      * the loading
      */

--- a/ymer/src/test/java/com/avanza/ymer/BasicDbObjectCompatibilityTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/BasicDbObjectCompatibilityTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import static com.avanza.ymer.BasicDbObjectCompatibility.convertToBasicDBObject;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.bson.Document;
+import org.junit.Test;
+
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+
+public class BasicDbObjectCompatibilityTest {
+	@Test
+	public void shouldConvertSimpleBsonDocument() {
+		// Arrange
+		final var d = new Document(Map.of(
+				"key", "value"
+		));
+
+		// Act
+		final var actual = convertToBasicDBObject(d);
+
+		// Assert
+		assertThat(actual.get("key"), equalTo("value"));
+	}
+
+	@Test
+	public void shouldConvertBsonDocumentWithList() {
+		// Arrange
+		final var d = new Document(Map.of(
+				"list", List.of(1, 2, 3)
+		));
+
+		// Act
+		final var actual = convertToBasicDBObject(d);
+
+		// Assert
+		BasicDBList list = (BasicDBList) actual.get("list");
+		assertThat(list, equalTo(List.of(1, 2, 3)));
+	}
+
+	@Test
+	public void shouldConvertBsonDocumentWithMap() {
+		// Arrange
+		final var d = new Document(Map.of(
+				"map", Map.of(
+						"key1", "value1",
+						"key2", "value2"
+				)
+		));
+
+		// Act
+		final var actual = convertToBasicDBObject(d);
+
+		// Assert
+		BasicDBObject map = (BasicDBObject) actual.get("map");
+		assertThat(map.keySet(), equalTo(Set.of("key1", "key2")));
+		assertThat(map.get("key1"), equalTo("value1"));
+		assertThat(map.get("key2"), equalTo("value2"));
+	}
+
+	@Test
+	public void shouldConvertComplexNestedBsonDocument() {
+		// Arrange
+		final var d = Document.parse("{"
+				+ "\"accountid\": 3133,"
+				+ "\"items\": ["
+				+ "  {\"productid\":1,\"quantity\":3},"
+				+ "  {\"productid\":2,\"quantity\":4,\"comment\":\"ok\"}"
+				+ "],"
+				+ "\"categories\":[[9], [7, 8]],"
+				+ "\"tags\":{\"tag1\": 1}},"
+				+ "\"vat\":null"
+				+ "}");
+
+		// Act
+		final var actual = convertToBasicDBObject(d);
+
+		// Assert
+		assertThat(actual.get("accountid"), equalTo(3133));
+		assertThat(actual.get("vat"), equalTo(null));
+
+		final var items = (BasicDBList) actual.get("items");
+		assertThat(items.size(), equalTo(2));
+
+		final var item1 = (BasicDBObject) items.get(0);
+		assertThat(item1.get("productid"), equalTo(1));
+		assertThat(item1.get("quantity"), equalTo(3));
+
+		final var item2 = (BasicDBObject) items.get(1);
+		assertThat(item2.get("productid"), equalTo(2));
+		assertThat(item2.get("quantity"), equalTo(4));
+		assertThat(item2.get("comment"), equalTo("ok"));
+
+		final var categories = (BasicDBList) actual.get("categories");
+		assertThat(categories, equalTo(List.of(
+				List.of(9),
+				List.of(7, 8)
+		)));
+
+		final var tags = (BasicDBObject) actual.get("tags");
+		assertThat(tags.get("tag1"), equalTo(1));
+	}
+}

--- a/ymer/src/test/java/com/avanza/ymer/BsonDocumentPatchTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/BsonDocumentPatchTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import static java.util.Comparator.comparingInt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.bson.Document;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.openspaces.core.cluster.ClusterInfo;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.convert.NoOpDbRefResolver;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+import com.gigaspaces.annotation.pojo.SpaceClass;
+import com.gigaspaces.annotation.pojo.SpaceId;
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+
+public class BsonDocumentPatchTest {
+
+	@ClassRule
+	public static final MirrorEnvironment mirrorEnvironment = new MirrorEnvironment();
+
+	@After
+	public void afterEachTest() {
+		mirrorEnvironment.reset();
+	}
+
+	@Test
+	public void shouldApplyDocumentPatchesToDocumentsWithComplexDatatypes() {
+		// Arrange
+		final var mirroredObjectDefinition = MirroredObjectDefinition
+				.create(ExampleObjectWithComplexDatatypes.class)
+				.documentPatches(
+						new PatchV1ToV2WithDeprecatedBasicDBObject(),
+						new PatchV2ToV3WithBsonDocumentPatch(),
+						new PatchV3ToV4WithDeprecatedBasicDBObject()
+				);
+		final var documentCollection = new MongoDocumentCollection(
+				mirrorEnvironment.getMongoTemplate().getCollection(mirroredObjectDefinition.collectionName())
+		);
+
+		documentCollection.insert(new Document(Map.of(
+				// No "_formatVersion" field.
+				"_id", 1,
+				"listOfMaps", List.of(Map.of("key", "value1")),
+				"mapOfLists", Map.of("key", List.of("value1")),
+				"accounts", List.of("a1", "a2")
+		)));
+		documentCollection.insert(new Document(Map.of(
+				"_id", 2,
+				"_formatVersion", 2,
+				"listOfMaps", List.of(Map.of("key", "value2")),
+				"mapOfLists", Map.of("key", List.of("value2")),
+				"accounts", List.of()
+		)));
+
+		final var spaceDataSource = (YmerSpaceDataSource) new YmerFactory(
+				() -> mirrorEnvironment.getMongoTemplate().getDb(),
+				new MappingMongoConverter(NoOpDbRefResolver.INSTANCE, new MongoMappingContext()),
+				List.of(mirroredObjectDefinition)
+		).createSpaceDataSource();
+		spaceDataSource.setClusterInfo(new ClusterInfo("", 1, 0, 1, 0));
+
+		// Act
+		final var loadedObjects = new ArrayList<ExampleObjectWithComplexDatatypes>();
+		spaceDataSource.initialDataLoad().forEachRemaining(
+				d -> loadedObjects.add((ExampleObjectWithComplexDatatypes) d)
+		);
+
+		// Assert
+		loadedObjects.sort(comparingInt(d -> d.id));
+		final var doc1 = documentCollection.findById(1);
+		final var expectedDoc1 = Document.parse("{"
+				+ "\"_id\":1,"
+				+ "\"_formatVersion\":4,"
+				+ "\"patch1applied\":true,"
+				+ "\"patch2applied\":true,"
+				+ "\"listOfMaps\":["
+				+ "  {\"key\":\"value1\"},"
+				+ "  {\"patch1listvalue\":\"value1\"},"
+				+ "  {\"patch2listvalue\":\"value1\"}"
+				+ "],"
+				+ "\"mapOfLists\":{"
+				+ "  \"key\":[\"value1\"],"
+				+ "  \"patch1mapvalue\":[\"value1\"],"
+				+ "  \"patch2mapvalue\":[\"value1\"]"
+				+ "},"
+				+ "\"accounts\":{"
+				+ "  \"a1\":\"patched\","
+				+ "  \"a2\":\"patched\""
+				+ "}"
+				+ "}");
+		assertThat(doc1, equalTo(expectedDoc1));
+
+		final var obj1 = loadedObjects.get(0);
+		assertThat(obj1.id, equalTo(1));
+		assertThat(obj1.patch1applied, equalTo(true));
+		assertThat(obj1.patch2applied, equalTo(true));
+		assertThat(obj1.listOfMaps, equalTo(List.of(
+				Map.of("key", "value1"),
+				Map.of("patch1listvalue", "value1"),
+				Map.of("patch2listvalue", "value1")
+		)));
+		assertThat(obj1.mapOfLists, equalTo(Map.of(
+				"key", List.of("value1"),
+				"patch1mapvalue", List.of("value1"),
+				"patch2mapvalue", List.of("value1")
+		)));
+		assertThat(obj1.accounts, equalTo(Map.of(
+				"a1", "patched",
+				"a2", "patched"
+		)));
+
+		final var doc2 = documentCollection.findById(2);
+		final var expectedDoc2 = Document.parse("{"
+				+ "\"_id\":2,"
+				+ "\"_formatVersion\":4,"
+				+ "\"patch2applied\":true,"
+				+ "\"listOfMaps\":["
+				+ "  {\"key\":\"value2\"},"
+				+ "  {\"patch2listvalue\":\"value2\"}"
+				+ "],"
+				+ "\"mapOfLists\":{"
+				+ "  \"key\":[\"value2\"],"
+				+ "  \"patch2mapvalue\":[\"value2\"]"
+				+ "},"
+				+ "\"accounts\":{}"
+				+ "}");
+		assertThat(doc2, equalTo(expectedDoc2));
+
+		final var obj2 = loadedObjects.get(1);
+		assertThat(obj2.id, equalTo(2));
+		assertThat(obj2.patch1applied, equalTo(false));
+		assertThat(obj2.patch2applied, equalTo(true));
+		assertThat(obj2.listOfMaps, equalTo(List.of(
+				Map.of("key", "value2"),
+				Map.of("patch2listvalue", "value2")
+		)));
+		assertThat(obj2.mapOfLists, equalTo(Map.of(
+				"key", List.of("value2"),
+				"patch2mapvalue", List.of("value2")
+		)));
+		assertThat(obj2.accounts, equalTo(Map.of()));
+	}
+
+	@SpaceClass
+	private static class ExampleObjectWithComplexDatatypes {
+
+		@Id
+		public int id;
+		public boolean patch1applied;
+		public boolean patch2applied;
+		public List<Map<String, String>> listOfMaps;
+		public Map<String, List<String>> mapOfLists;
+		public Map<String, String> accounts;
+
+		@SpaceId
+		public int getId() {
+			return id;
+		}
+	}
+
+	private static class PatchV1ToV2WithDeprecatedBasicDBObject implements DocumentPatch {
+		@Override
+		public void apply(BasicDBObject dbObject) {
+			dbObject.put("patch1applied", true);
+
+			// Before: listOfMaps: [{"key":"value0"}]
+			// After:  listOfMaps: [{"key":"value0"}, {"patch1listvalue": "value0"}]
+			var listOfMaps = (BasicDBList) dbObject.get("listOfMaps");
+			listOfMaps.add(new BasicDBObject("patch1listvalue", ((BasicDBObject) listOfMaps.get(0)).get("key")));
+
+			// Before: mapOfLists: {"key":["value0"]}
+			// After:  mapOfLists: {"key":["value0"], "patch1mapvalue":["value0"]}
+			var mapOfLists = (BasicDBObject) dbObject.get("mapOfLists");
+			var list = new BasicDBList();
+			list.add(((BasicDBList) mapOfLists.get("key")).get(0));
+			mapOfLists.put("patch1mapvalue", list);
+		}
+
+		@Override
+		public int patchedVersion() {
+			return 1;
+		}
+	}
+
+	private static class PatchV2ToV3WithBsonDocumentPatch implements BsonDocumentPatch {
+		@Override
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		public void apply(Document document) {
+			document.put("patch2applied", true);
+
+			// Before: listOfMaps: [{"key":"value0"}]
+			// After:  listOfMaps: [{"key":"value0"}, {"patch2listvalue": "value0"}]
+			var listOfMaps = (List) document.get("listOfMaps");
+			listOfMaps.add(Map.of("patch2listvalue", ((Map) listOfMaps.get(0)).get("key")));
+
+			// Before: mapOfLists: {"key":["value0"]}
+			// After:  mapOfLists: {"key":["value0"], "patch2mapvalue":["value0"]}
+			var mapOfLists = (Map) document.get("mapOfLists");
+			mapOfLists.put("patch2mapvalue", List.of(
+					((List) mapOfLists.get("key")).get(0)
+			));
+		}
+
+		@Override
+		public int patchedVersion() {
+			return 2;
+		}
+	}
+
+	private static class PatchV3ToV4WithDeprecatedBasicDBObject implements DocumentPatch {
+		@Override
+		public void apply(BasicDBObject basicDBObject) {
+			// Before: accounts: ["a1", "a2"]
+			// After:  accounts: {"a1":"patched", "a2":"patched"}
+			var accountMap = new BasicDBObject();
+			((BasicDBList) basicDBObject.remove("accounts"))
+					.forEach(a -> accountMap.put((String) a, "patched"));
+			basicDBObject.put("accounts", accountMap);
+		}
+
+		@Override
+		public int patchedVersion() {
+			return 3;
+		}
+	}
+}


### PR DESCRIPTION
* When converting `org.bson.Document` to `com.mongodb.BasicDBObject`, also convert all field values in the same way, not only the top-level object.
* Reason for changing is to support documentpatches that use `DocumentPatch` instead of `BsonDocumentPatch`, that handle documents with complex datatypes.