### PR TITLE
TP-1181: Prevent NPE when deleting `persistInstanceId` objs

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObject.java
@@ -142,13 +142,19 @@ final class MirroredObject<T> {
 	}
 
 	private void setInstanceIdFields(Document document, InstanceMetadata metadata) {
+		final Object routingKey = document.get(DOCUMENT_ROUTING_KEY);
+		if (routingKey == null) {
+			// routingkey is null in DELETE-operations.
+			return;
+		}
+
 		Set<Integer> numberOfInstancesToCalculateFor = Stream.concat(
 				metadata.getNumberOfInstances().stream(),
 				metadata.getNextNumberOfInstances().stream()
 		).collect(toSet());
 
 		numberOfInstancesToCalculateFor.forEach(numberOfInstances -> {
-			int instanceId = getInstanceId(document.get(DOCUMENT_ROUTING_KEY), numberOfInstances);
+			int instanceId = getInstanceId(routingKey, numberOfInstances);
 			document.put(getInstanceIdFieldName(numberOfInstances), instanceId);
 		});
 	}

--- a/ymer/src/test/java/com/avanza/ymer/PersistedInstanceIdCalculationServiceTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/PersistedInstanceIdCalculationServiceTest.java
@@ -18,6 +18,7 @@ package com.avanza.ymer;
 import static com.avanza.ymer.MirroredObject.DOCUMENT_ROUTING_KEY;
 import static com.avanza.ymer.PersistedInstanceIdUtil.getInstanceIdFieldName;
 import static com.avanza.ymer.TestSpaceMirrorObjectDefinitions.TEST_SPACE_OBJECT;
+import static com.avanza.ymer.TestSpaceMirrorObjectDefinitions.TEST_SPACE_OBJECT_CUSTOM_ROUTINGKEY;
 import static com.avanza.ymer.TestSpaceMirrorObjectDefinitions.TEST_SPACE_OTHER_OBJECT;
 import static com.avanza.ymer.util.GigaSpacesInstanceIdUtil.getInstanceId;
 import static com.j_spaces.core.Constants.Mirror.FULL_MIRROR_SERVICE_CLUSTER_PARTITIONS_COUNT;
@@ -144,6 +145,7 @@ public class PersistedInstanceIdCalculationServiceTest {
 				assertThat(target.getNumberOfPartitionsThatDataIsPreparedFor(), is(new int[] { }));
 
 				target.calculatePersistedInstanceId(TEST_SPACE_OTHER_OBJECT.collectionName());
+				target.calculatePersistedInstanceId(TEST_SPACE_OBJECT_CUSTOM_ROUTINGKEY.collectionName());
 				verifyStatistics(TEST_SPACE_OTHER_OBJECT, target, new int[] { 22 });
 
 				// Now that all collections are calculated, this should contain number of instances

--- a/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
+++ b/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
@@ -42,12 +42,17 @@ public class TestSpaceMirrorObjectDefinitions implements MirroredObjectsConfigur
 			MirroredObjectDefinition.create(TestSpaceThirdObject.class)
 					.documentPatches(new TestSpaceThirdObject.TestSpaceThirdObjectPatchV1());
 
+	public static final MirroredObjectDefinition<TestSpaceObjectWithCustomRoutingKey> TEST_SPACE_OBJECT_CUSTOM_ROUTINGKEY =
+			MirroredObjectDefinition.create(TestSpaceObjectWithCustomRoutingKey.class)
+					.persistInstanceId(true);
+
 	@Override
 	public Collection<MirroredObjectDefinition<?>> getMirroredObjectDefinitions() {
 		return Arrays.asList(
 				TEST_SPACE_OBJECT,
 				TEST_SPACE_OTHER_OBJECT,
-				TEST_SPACE_THIRD_OBJECT
+				TEST_SPACE_THIRD_OBJECT,
+				TEST_SPACE_OBJECT_CUSTOM_ROUTINGKEY
 		);
 	}
 }

--- a/ymer/src/test/java/com/avanza/ymer/TestSpaceObjectWithCustomRoutingKey.java
+++ b/ymer/src/test/java/com/avanza/ymer/TestSpaceObjectWithCustomRoutingKey.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import java.util.Objects;
+
+import org.springframework.data.annotation.Id;
+
+import com.gigaspaces.annotation.pojo.SpaceId;
+import com.gigaspaces.annotation.pojo.SpaceRouting;
+
+public class TestSpaceObjectWithCustomRoutingKey {
+
+	@Id
+	private String id;
+	private String customRoutingKey;
+
+	public TestSpaceObjectWithCustomRoutingKey(String id, String customRoutingKey) {
+		this.id = id;
+		this.customRoutingKey = customRoutingKey;
+	}
+
+	public TestSpaceObjectWithCustomRoutingKey() {
+	}
+
+	@SpaceId
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	@SpaceRouting
+	public String getCustomRoutingKey() {
+		return customRoutingKey;
+	}
+
+	public void setCustomRoutingKey(String customRoutingKey) {
+		this.customRoutingKey = customRoutingKey;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		TestSpaceObjectWithCustomRoutingKey that = (TestSpaceObjectWithCustomRoutingKey) o;
+		return id.equals(that.id) && customRoutingKey.equals(that.customRoutingKey);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, customRoutingKey);
+	}
+
+	@Override
+	public String toString() {
+		return "TestSpaceObjectWithCustomRoutingKey [id=" + id + ", customRoutingKey=" + customRoutingKey + "]";
+	}
+}


### PR DESCRIPTION
* Prevents the exeption listed below, which happens when deleting a space object whose routing key is null.
* The routing key can be null if the space object defines another routing key than the id, and performs a delete-by-id operation.

```
java.lang.NullPointerException: null
	at com.avanza.ymer.util.GigaSpacesInstanceIdUtil.getInstanceId(GigaSpacesInstanceIdUtil.java:48) ~[ymer-3.0.5.jar:3.0.5]
	at com.avanza.ymer.MirroredObject.lambda$setInstanceIdFields$0(MirroredObject.java:151) ~[ymer-3.0.5.jar:3.0.5]
	at java.lang.Iterable.forEach(Iterable.java:75) ~[?:?]
	at com.avanza.ymer.MirroredObject.setInstanceIdFields(MirroredObject.java:150) ~[ymer-3.0.5.jar:3.0.5]
	at com.avanza.ymer.MirroredObject.setDocumentAttributes(MirroredObject.java:128) ~[ymer-3.0.5.jar:3.0.5]
	at com.avanza.ymer.SpaceMirrorContext.toVersionedDocument(SpaceMirrorContext.java:114) ~[ymer-3.0.5.jar:3.0.5]
	at com.avanza.ymer.MirroredObjectWriter$MongoCommand.execute(MirroredObjectWriter.java:164) ~[ymer-3.0.5.jar:3.0.5]
	at com.avanza.ymer.MirroredObjectWriter.remove(MirroredObjectWriter.java:113) ~[ymer-3.0.5.jar:3.0.5]
	at com.avanza.ymer.MirroredObjectWriter.executeBulk(MirroredObjectWriter.java:72) ~[ymer-3.0.5.jar:3.0.5]
	at com.avanza.ymer.YmerSpaceSynchronizationEndpoint.onOperationsBatchSynchronization(YmerSpaceSynchronizationEndpoint.java:77) ~[ymer-3.0.5.jar:3.0.5]
```