### PR TITLE
TP-1209: Add statistics to BulkMirroredObjectWriter

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/BulkMirroredObjectWriter.java
+++ b/ymer/src/main/java/com/avanza/ymer/BulkMirroredObjectWriter.java
@@ -31,6 +31,7 @@ import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.avanza.ymer.PerformedOperationsListener.OperationType;
 import com.gigaspaces.sync.DataSyncOperation;
 import com.gigaspaces.sync.OperationsBatchData;
 import com.mongodb.MongoBulkWriteException;
@@ -45,6 +46,13 @@ final class BulkMirroredObjectWriter {
 	private final DocumentWriteExceptionHandler exceptionHandler;
 	private final MirroredObjectFilterer objectFilterer;
 	private final PerformedOperationsListener operationsListener;
+
+	BulkMirroredObjectWriter(SpaceMirrorContext mirror,
+			DocumentWriteExceptionHandler exceptionHandler,
+			MirroredObjectFilterer mirroredObjectFilterer) {
+		this(mirror, exceptionHandler, mirroredObjectFilterer, (type, delta) -> {
+		});
+	}
 
 	BulkMirroredObjectWriter(SpaceMirrorContext mirror,
 			DocumentWriteExceptionHandler exceptionHandler,
@@ -83,8 +91,9 @@ final class BulkMirroredObjectWriter {
 
 		changesByCollection.forEach((collectionName, bulkChanges) -> {
 			List<MongoBulkChange> remainingChanges = bulkChanges;
+			int attempt = 1;
 			while (!remainingChanges.isEmpty()) {
-				remainingChanges = executeMongoDbBulk(collectionName, metadata, remainingChanges);
+				remainingChanges = executeMongoDbBulk(collectionName, metadata, remainingChanges, attempt++);
 			}
 		});
 	}
@@ -95,8 +104,11 @@ final class BulkMirroredObjectWriter {
 	 * @return list of changes that weren't written and needs to be retried.
 	 *         This happens if a row in a bulkWrite failed and needs to be skipped.
 	 */
-	private List<MongoBulkChange> executeMongoDbBulk(String collectionName, InstanceMetadata metadata, List<MongoBulkChange> changes) {
-		Map<Integer, Integer> bulkChangeIdToChangeMap = new HashMap<>();
+	private List<MongoBulkChange> executeMongoDbBulk(String collectionName,
+			InstanceMetadata metadata,
+			List<MongoBulkChange> changes,
+			int attempt) {
+		final Map<Integer, Integer> bulkChangeIdToChangeMap = new HashMap<>();
 		try {
 			DocumentCollection collection = mirror.getDocumentCollection(collectionName);
 
@@ -113,8 +125,12 @@ final class BulkMirroredObjectWriter {
 						versionedDocument = mirror.toVersionedDocument(change.object, metadata);
 						mirror.getPreWriteProcessing(change.object.getClass()).preWrite(versionedDocument);
 					} catch (Exception e) {
-						mirror.onMirrorException(e, change.operation, change.object);
-						exceptionHandler.handleException(e, "Conversion failed, operation: " + change.operation + ", change: " + change.object);
+						// after the first attempt, this error will already have been logged & handled earlier on
+						if (attempt == 1) {
+							mirror.onMirrorException(e, change.operation, change.object);
+							exceptionHandler.handleException(e, "Conversion failed, operation: " + change.operation + ", change: " + change.object);
+							operationsListener.increment(OperationType.FAILURE, 1);
+						}
 						continue;
 					}
 
@@ -147,29 +163,31 @@ final class BulkMirroredObjectWriter {
 			BulkWriteError writeError = e.getWriteErrors().get(0); // always a single write error as we use an ordered operation
 			MongoBulkChange failedChange = changes.get(writeError.getIndex());
 			mirror.onMirrorException(e, failedChange.operation, failedChange.object);
+			operationsListener.increment(OperationType.FAILURE, 1);
 
 			int failedChangeIndex = bulkChangeIdToChangeMap.get(writeError.getIndex());
 			List<MongoBulkChange> remainingChanges = changes.subList(failedChangeIndex + 1, changes.size());
 
 			if (!remainingChanges.isEmpty()) {
-				logger.error("Bulk write failed on a {} operation in collection {}: \"{}\". Will continue writing remaining {} changes",
-						failedChange.operation, collectionName, writeError.getMessage(), remainingChanges.size());
+				logger.error("Bulk write failed attempt {} on a {} operation in collection {}: \"{}\". Will continue writing remaining {} changes",
+						attempt, failedChange.operation, collectionName, writeError.getMessage(), remainingChanges.size());
 			} else {
-				logger.error("Bulk write failed on a {} operation in collection {}: \"{}\". This was the last entry in the batch",
-						failedChange.operation, collectionName, writeError.getMessage(), e);
+				logger.error("Bulk write failed attempt {} on a {} operation in collection {}: \"{}\". This was the last entry in the batch",
+						attempt, failedChange.operation, collectionName, writeError.getMessage(), e);
 			}
 
 			return remainingChanges;
 		} catch (Exception e) {
 			exceptionHandler.handleException(e, "Operation: Bulk write, changes: " + changes);
+			operationsListener.increment(OperationType.FAILURE, changes.size());
 			return emptyList();
 		}
 	}
 
 	private void addResultToStatistics(BulkWriteResult result) {
-		operationsListener.increment(PerformedOperationsListener.OperationType.INSERT, result.getInsertedCount());
-		operationsListener.increment(PerformedOperationsListener.OperationType.UPDATE, result.getMatchedCount());
-		operationsListener.increment(PerformedOperationsListener.OperationType.DELETE, result.getDeletedCount());
+		operationsListener.increment(OperationType.INSERT, result.getInsertedCount());
+		operationsListener.increment(OperationType.UPDATE, result.getMatchedCount());
+		operationsListener.increment(OperationType.DELETE, result.getDeletedCount());
 	}
 
 	private void checkBulkResultForWarnings(int expectedUpdates, int expectedRemovals, BulkWriteResult result) {

--- a/ymer/src/main/java/com/avanza/ymer/BulkMirroredObjectWriter.java
+++ b/ymer/src/main/java/com/avanza/ymer/BulkMirroredObjectWriter.java
@@ -15,6 +15,7 @@
  */
 package com.avanza.ymer;
 
+import static com.avanza.ymer.PerformedOperationsListener.OperationType.READ_BATCH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -58,6 +59,7 @@ final class BulkMirroredObjectWriter {
 	}
 
 	public void executeBulk(InstanceMetadata metadata, OperationsBatchData batch) {
+		operationsListener.increment(READ_BATCH, batch.getBatchDataItems().length);
 		Map<String, List<MongoBulkChange>> changesByCollection = new HashMap<>();
 
 		for (DataSyncOperation bulkItem : objectFilterer.filterSpaceObjects(batch.getBatchDataItems())) {
@@ -152,8 +154,8 @@ final class BulkMirroredObjectWriter {
 	private void checkResultForWarnings(int expectedUpdates, int expectedRemovals, BulkWriteResult result) {
 		if (expectedUpdates != result.getMatchedCount()) {
 			logger.warn("Tried to update {} documents in current bulk write, but only {} were matched by query. "
-					+ "MongoDB and space seems to be out of sync! "
-					+ "The following ids were inserted into MongoDB as a result of update operations: [{}].",
+							+ "MongoDB and space seems to be out of sync! "
+							+ "The following ids were inserted into MongoDB as a result of update operations: [{}].",
 					expectedUpdates, result.getMatchedCount(),
 					result.getUpserts().stream()
 							.map(bson -> bson.getId().asString().getValue())

--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectWriter.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectWriter.java
@@ -43,7 +43,7 @@ final class MirroredObjectWriter {
 			DocumentWriteExceptionHandler exceptionHandler,
 			MirroredObjectFilterer mirroredObjectFilterer) {
 		this.mirror = Objects.requireNonNull(mirror);
-		this.exceptionHandler = Objects.requireNonNull(exceptionHandler);;
+		this.exceptionHandler = Objects.requireNonNull(exceptionHandler);
 		this.mirroredObjectFilterer = Objects.requireNonNull(mirroredObjectFilterer);
 	}
 

--- a/ymer/src/main/java/com/avanza/ymer/RethrowsTransientDocumentWriteExceptionHandler.java
+++ b/ymer/src/main/java/com/avanza/ymer/RethrowsTransientDocumentWriteExceptionHandler.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoNotPrimaryException;
 import com.mongodb.MongoSocketException;
@@ -75,10 +76,19 @@ class RethrowsTransientDocumentWriteExceptionHandler implements DocumentWriteExc
 	}
 
 	private void logIrrecoverableError(Exception e, String operationDescription) {
-		log.error(
-				"Exception when executing mirror command! Attempted operation: {} - This command will be ignored but the rest of the commands in this bulk will be attempted. This can lead to data inconsistency in the mongo database. Must be investigated ASAP. If this error was preceeded by a TransientDocumentWriteException the cause might be that we reattempt already performed operations, which might be fine.",
-				operationDescription,
-				e);
+		if (e instanceof MongoBulkWriteException) {
+			log.error("Exception when executing mirror command! Attempted to write in bulk but it was aborted with error: {}."
+					+ "This can lead to data inconsistency in the mongo database. "
+					+ "Must be investigated ASAP.",
+					operationDescription, e);
+		} else {
+			log.error(
+					"Exception when executing mirror command! Attempted operation: {} - This command will be ignored but the rest of the commands in this bulk will be attempted. "
+							+ "This can lead to data inconsistency in the mongo database. "
+							+ "Must be investigated ASAP. "
+							+ "If this error was preceeded by a TransientDocumentWriteException the cause might be that we reattempt already performed operations, which might be fine.",
+					operationDescription, e);
+		}
 	}
 
 }

--- a/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
+++ b/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
@@ -70,8 +70,8 @@ final class YmerSpaceSynchronizationEndpoint extends SpaceSynchronizationEndpoin
 		this.spaceMirror = spaceMirror;
 		this.operationStatistics = new PerformedOperationMetrics();
 		final MirroredObjectFilterer mirroredObjectFilterer = new MirroredObjectFilterer(spaceMirror);
-		this.mirroredObjectWriter = new MirroredObjectWriter(spaceMirror, exceptionHandler, mirroredObjectFilterer);
-		this.bulkMirroredObjectWriter = new BulkMirroredObjectWriter(spaceMirror, exceptionHandler, mirroredObjectFilterer);
+		this.mirroredObjectWriter = new MirroredObjectWriter(spaceMirror, exceptionHandler, mirroredObjectFilterer, operationStatistics);
+		this.bulkMirroredObjectWriter = new BulkMirroredObjectWriter(spaceMirror, exceptionHandler, mirroredObjectFilterer, operationStatistics);
 		this.persistedInstanceIdCalculationService = new PersistedInstanceIdCalculationService(spaceMirror, ymerProperties);
 		this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(THREAD_FACTORY);
 		this.ymerProperties = ymerProperties;

--- a/ymer/src/test/java/com/avanza/ymer/BulkMirroredObjectWriterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/BulkMirroredObjectWriterTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer;
+
+import static com.avanza.ymer.TestSpaceMirrorObjectDefinitions.TEST_SPACE_OBJECT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.bson.Document;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.avanza.ymer.helper.FakeBatchData;
+import com.avanza.ymer.helper.FakeBulkItem;
+import com.gigaspaces.sync.DataSyncOperationType;
+
+public class BulkMirroredObjectWriterTest {
+
+	private MockExceptionHandler mockExceptionHandler;
+	private BulkMirroredObjectWriter bulkMirroredObjectWriter;
+	private InstanceMetadata testMetadata = new InstanceMetadata(1, null);
+	private DocumentDb documentDb;
+	private SpaceMirrorContext mirror;
+
+	private static class MockExceptionHandler implements DocumentWriteExceptionHandler {
+		private final List<Exception> exceptions = new ArrayList<>();
+		private final List<String> descriptions = new ArrayList<>();
+
+		@Override
+		public void handleException(Exception exception, String operationDescription) {
+			this.exceptions.add(exception);
+			this.descriptions.add(operationDescription);
+		}
+
+		public void reset() {
+			exceptions.clear();
+			descriptions.clear();
+		}
+	}
+
+	@Before
+	public void setUp() {
+		documentDb = FakeDocumentDb.create();
+		mockExceptionHandler = new MockExceptionHandler();
+		TestSpaceMirrorObjectDefinitions definitions = new TestSpaceMirrorObjectDefinitions();
+		mirror = new SpaceMirrorContext(
+				new MirroredObjects(definitions.getMirroredObjectDefinitions().stream(), MirroredObjectDefinitionsOverride.noOverride()),
+				TestSpaceObjectFakeConverter.create(),
+				documentDb,
+				SpaceMirrorContext.NO_EXCEPTION_LISTENER,
+				Plugins.empty(),
+				1);
+
+		bulkMirroredObjectWriter = new BulkMirroredObjectWriter(
+				mirror,
+				mockExceptionHandler,
+				new MirroredObjectFilterer(mirror)
+		);
+	}
+
+	@Test
+	public void shouldAbortRetriesAfterTooManyFailures() {
+		int numObjects = 10_000;
+
+		TestSpaceObject[] objects = IntStream.range(1, numObjects)
+				.mapToObj(i -> new TestSpaceObject("id_" + i, "message" + i))
+				.toArray(TestSpaceObject[]::new);
+
+		// This will cause each write to fail as all the objects already exists in DB
+		documentDb.getCollection(TEST_SPACE_OBJECT.collectionName())
+				.insertAll(Stream.of(objects)
+						.map(a -> mirror.toVersionedDocument(a, testMetadata))
+						.toArray(Document[]::new));
+
+		// This would lead to a StackOverflowError if the retries are not cancelled
+		bulkMirroredObjectWriter.executeBulk(testMetadata, new FakeBatchData(
+				Stream.of(objects)
+						.map(spaceObject -> new FakeBulkItem(spaceObject, DataSyncOperationType.WRITE))
+						.toArray(FakeBulkItem[]::new)
+		));
+
+		assertThat(mockExceptionHandler.descriptions, contains("Aborted bulk operation"));
+	}
+}

--- a/ymer/src/test/java/com/avanza/ymer/BulkMirroredObjectWriterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/BulkMirroredObjectWriterTest.java
@@ -76,7 +76,8 @@ public class BulkMirroredObjectWriterTest {
 		bulkMirroredObjectWriter = new BulkMirroredObjectWriter(
 				mirror,
 				mockExceptionHandler,
-				new MirroredObjectFilterer(mirror)
+				new MirroredObjectFilterer(mirror),
+				new PerformedOperationMetrics()
 		);
 	}
 

--- a/ymer/src/test/java/com/avanza/ymer/BulkMirroredObjectWriterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/BulkMirroredObjectWriterTest.java
@@ -20,7 +20,6 @@ import static com.avanza.ymer.TestSpaceMirrorObjectDefinitions.TEST_SPACE_OTHER_
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -56,6 +55,7 @@ public class BulkMirroredObjectWriterTest {
 	private SpaceMirrorContext mirror;
 	private MirrorExceptionSpy mirrorExceptionSpy;
 	private DocumentConverter documentConverter;
+	private PerformedOperationMetrics metrics;
 
 	@Before
 	public void setUp() {
@@ -63,6 +63,7 @@ public class BulkMirroredObjectWriterTest {
 		mirrorExceptionSpy = new MirrorExceptionSpy();
 		exceptionHandler = new FakeDocumentWriteExceptionHandler();
 		documentConverter = TestSpaceObjectFakeConverter.create();
+		metrics = new PerformedOperationMetrics();
 		TestSpaceMirrorObjectDefinitions definitions = new TestSpaceMirrorObjectDefinitions();
 		mirror = new SpaceMirrorContext(
 				new MirroredObjects(definitions.getMirroredObjectDefinitions().stream(), MirroredObjectDefinitionsOverride.noOverride()),
@@ -76,7 +77,7 @@ public class BulkMirroredObjectWriterTest {
 				mirror,
 				exceptionHandler,
 				new MirroredObjectFilterer(mirror),
-				new PerformedOperationMetrics()
+				metrics
 		);
 	}
 
@@ -118,6 +119,10 @@ public class BulkMirroredObjectWriterTest {
 
 		// After bulkWrite, the last 800 rows should be written to db
 		assertThat(documentDb.getCollection(TEST_SPACE_OBJECT.collectionName()).findAll().count(), is(1_000L));
+
+		// verify recorded metrics
+		assertThat(metrics.getNumInserts(), is(800L));
+		assertThat(metrics.getNumFailures(), is(200L));
 	}
 
 	@Test
@@ -129,7 +134,7 @@ public class BulkMirroredObjectWriterTest {
 		// This will cause each write to fail as all the objects already exists in DB
 		documentDb.getCollection(TEST_SPACE_OBJECT.collectionName())
 				.insertAll(Stream.of(objects)
-						.map(a -> mirror.toVersionedDocument(a, testMetadata))
+						.map(o -> mirror.toVersionedDocument(o, testMetadata))
 						.toArray(Document[]::new));
 
 		// Before bulkWrite, 5 rows should already be written
@@ -149,6 +154,10 @@ public class BulkMirroredObjectWriterTest {
 
 		// no more rows should be added
 		assertThat(documentDb.getCollection(TEST_SPACE_OBJECT.collectionName()).findAll().count(), is(5L));
+
+		// verify recorded metrics
+		assertThat(metrics.getNumInserts(), is(0L));
+		assertThat(metrics.getNumFailures(), is(5L));
 	}
 
 	@Test
@@ -167,6 +176,10 @@ public class BulkMirroredObjectWriterTest {
 				})
 				.toArray(TestSpaceObject[]::new);
 
+		// Cause a writing failure in the middle of the operation
+		documentDb.getCollection(TEST_SPACE_OBJECT.collectionName())
+				.insert(mirror.toVersionedDocument(objects[50], testMetadata));
+
 		bulkMirroredObjectWriter.executeBulk(testMetadata, new FakeBatchData(
 				Stream.of(objects)
 						.map(spaceObject -> new FakeBulkItem(spaceObject, DataSyncOperationType.WRITE))
@@ -174,10 +187,7 @@ public class BulkMirroredObjectWriterTest {
 		));
 
 		// Every second row should have failed conversion and been added as an exception
-		assertThat(mirrorExceptionSpy.getExceptionCount(), is(50));
-		assertThat(mirrorExceptionSpy.getLastException().getMessage(),
-				startsWith("Could not convert TestSpaceObject")
-		);
+		assertThat(mirrorExceptionSpy.getExceptionCount(), is(51));
 
 		// Every second row should have been written to db
 		List<Document> objectsInDb = documentDb.getCollection(TEST_SPACE_OBJECT.collectionName()).findAll().collect(toList());
@@ -190,6 +200,10 @@ public class BulkMirroredObjectWriterTest {
 								.toArray(String[]::new)
 				)
 		);
+
+		// verify recorded metrics
+		assertThat(metrics.getNumInserts(), is(49L));
+		assertThat(metrics.getNumFailures(), is(51L));
 	}
 
 	@Test
@@ -241,6 +255,10 @@ public class BulkMirroredObjectWriterTest {
 
 		List<Document> persisted = documentDb.getCollection(mirroredObject.getCollectionName()).findAll().collect(toList());
 		assertEquals(3, persisted.size());
+
+		// verify recorded metrics
+		assertThat(metrics.getNumInserts(), is(3L));
+		assertThat(metrics.getNumFailures(), is(0L));
 	}
 
 	@Test
@@ -309,6 +327,11 @@ public class BulkMirroredObjectWriterTest {
 		List<Document> persisted = documentDb.getCollection(mirroredObject.getCollectionName()).findAll().collect(toList());
 		assertEquals(1, persisted.size());
 		assertEquals(expected, persisted.get(0));
+
+		// verify recorded metrics
+		assertThat(metrics.getNumInserts(), is(0L));
+		assertThat(metrics.getNumUpdates(), is(1L));
+		assertThat(metrics.getNumFailures(), is(0L));
 	}
 
 	@Test
@@ -330,6 +353,11 @@ public class BulkMirroredObjectWriterTest {
 		List<Document> persisted = documentDb.getCollection(mirroredObject.getCollectionName()).findAll().collect(toList());
 		assertEquals(1, persisted.size());
 		assertEquals(expected, persisted.get(0));
+
+		// verify recorded metrics
+		assertThat(metrics.getNumInserts(), is(0L));
+		assertThat(metrics.getNumUpdates(), is(1L));
+		assertThat(metrics.getNumFailures(), is(0L));
 	}
 
 	@Test
@@ -347,6 +375,11 @@ public class BulkMirroredObjectWriterTest {
 
 		List<Document> persisted = documentDb.getCollection(mirroredObject.getCollectionName()).findAll().collect(toList());
 		assertEquals(0, persisted.size());
+
+		// verify recorded metrics
+		assertThat(metrics.getNumInserts(), is(0L));
+		assertThat(metrics.getNumDeletes(), is(1L));
+		assertThat(metrics.getNumFailures(), is(0L));
 	}
 
 	@Test
@@ -364,6 +397,11 @@ public class BulkMirroredObjectWriterTest {
 		List<Document> persisted = documentDb.getCollection(anotherMirroredDocument.getCollectionName()).findAll().collect(toList());
 		assertEquals(1, persisted.size());
 		assertEquals(expected, persisted.get(0));
+
+		// verify recorded metrics
+		assertThat(metrics.getNumInserts(), is(0L));
+		assertThat(metrics.getNumDeletes(), is(0L));
+		assertThat(metrics.getNumFailures(), is(0L));
 	}
 
 	@Test
@@ -455,6 +493,10 @@ public class BulkMirroredObjectWriterTest {
 		assertEquals(2, persisted.size());
 		assertEquals(2, persisted.get(0).get("_id"));
 		assertEquals(3, persisted.get(1).get("_id"));
+
+		// verify recorded metrics
+		assertThat(metrics.getNumInserts(), is(2L));
+		assertThat(metrics.getNumFailures(), is(0L));
 	}
 
 	private DocumentDb throwsOnUpdateDocumentDb() {

--- a/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
+++ b/ymer/src/test/java/com/avanza/ymer/FakeDocumentCollection.java
@@ -63,6 +63,12 @@ class FakeDocumentCollection implements DocumentCollection {
 	private final Set<IndexInfo> indexes = ConcurrentHashMap.newKeySet();
 	private final AtomicInteger idGenerator = new AtomicInteger(0);
 
+	private Supplier<RuntimeException> bulkException;
+
+	public void setBulkException(Supplier<RuntimeException> bulkException) {
+		this.bulkException = bulkException;
+	}
+
 	FakeDocumentCollection() {
 		indexes.add(new IndexInfo(singletonList(IndexField.create("_id", ASC)), "_id_", false, false, ""));
 	}
@@ -112,6 +118,10 @@ class FakeDocumentCollection implements DocumentCollection {
 	}
 
 	private BulkWriteResult mockedBulkWrite(Consumer<BulkWriter> bulkWriter) {
+		if (bulkException != null) {
+			throw bulkException.get();
+		}
+
 		LongAdder inserts = new LongAdder();
 		LongAdder updates = new LongAdder();
 		LongAdder deletes = new LongAdder();

--- a/ymer/src/test/java/com/avanza/ymer/MirrorEnvironment.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirrorEnvironment.java
@@ -40,7 +40,7 @@ import com.mongodb.client.MongoDatabase;
 public class MirrorEnvironment extends ExternalResource {
 
 	public static final String TEST_MIRROR_DB_NAME = "mirror_test_db";
-	private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:3.6");
+	private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.0");
 	private final MongoClient mongoClient;
 
 	public MirrorEnvironment() {

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
@@ -31,12 +31,9 @@ import org.junit.Test;
 import org.springframework.data.mongodb.core.query.Query;
 
 import com.avanza.ymer.YmerInitialLoadIntegrationTest.TestSpaceObjectV1Patch;
-import com.gigaspaces.document.SpaceDocument;
-import com.gigaspaces.metadata.SpaceTypeDescriptor;
-import com.gigaspaces.sync.DataSyncOperation;
+import com.avanza.ymer.helper.FakeBatchData;
+import com.avanza.ymer.helper.FakeBulkItem;
 import com.gigaspaces.sync.DataSyncOperationType;
-import com.gigaspaces.sync.OperationsBatchData;
-import com.gigaspaces.sync.SynchronizationSourceDetails;
 
 public class MirroredObjectWriterTest {
 
@@ -344,91 +341,6 @@ public class MirroredObjectWriterTest {
 			this.lastException = e;
 		}
 
-	}
-
-	private static class FakeBatchData implements OperationsBatchData {
-
-		private final DataSyncOperation[] batchDataItems;
-
-		private FakeBatchData(FakeBulkItem[] items) {
-			batchDataItems = items;
-		}
-
-		public static FakeBatchData create(FakeBulkItem... items) {
-			return new FakeBatchData(items);
-		}
-
-		@Override
-		public DataSyncOperation[] getBatchDataItems() {
-			return this.batchDataItems;
-		}
-
-		@Override
-		public SynchronizationSourceDetails getSourceDetails() {
-			return () -> "spaceName_container1_1:spaceName";
-		}
-
-	}
-
-	public static class FakeBulkItem implements DataSyncOperation {
-
-		private final Object item;
-		private final DataSyncOperationType operation;
-
-		public FakeBulkItem(Object item, DataSyncOperationType operation) {
-			this.item = item;
-			this.operation = operation;
-		}
-
-		@Override
-		public Object getDataAsObject() {
-			return this.item;
-		}
-
-		@Override
-		public DataSyncOperationType getDataSyncOperationType() {
-			return operation;
-		}
-
-		@Override
-		public Object getSpaceId() {
-			return null;
-		}
-
-		@Override
-		public SpaceTypeDescriptor getTypeDescriptor() {
-			return null;
-		}
-
-		@Override
-		public String getUid() {
-			return null;
-		}
-
-		@Override
-		public boolean supportsDataAsDocument() {
-			return false;
-		}
-
-		@Override
-		public boolean supportsDataAsObject() {
-			return false;
-		}
-
-		@Override
-		public boolean supportsGetSpaceId() {
-			return false;
-		}
-
-		@Override
-		public boolean supportsGetTypeDescriptor() {
-			return false;
-		}
-
-		@Override
-		public SpaceDocument getDataAsDocument() {
-			return null;
-		}
 	}
 
 }

--- a/ymer/src/test/java/com/avanza/ymer/YmerBulkMirrorIntegrationTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/YmerBulkMirrorIntegrationTest.java
@@ -44,14 +44,21 @@ public class YmerBulkMirrorIntegrationTest extends YmerMirrorIntegrationTestBase
 		TestSpaceObject object2 = new TestSpaceObject("id_2", "message2");
 
 		// This will cause the insert to fail on this object as it already exists in mongo when added to the gigaspace
-		mongo.insert(object1, TEST_SPACE_OBJECT.collectionName());
+		mongo.insert(object2, TEST_SPACE_OBJECT.collectionName());
 
-		// This object would not be written if no retries are made
+		// This message will not be inserted into the space as it is already persisted with "message2"
+		object2.setMessage("THIS_WILL_NOT_BE_WRITTEN");
+
+		// This object would not be written if no retries are made as "object2" will fail
 		TestSpaceObject object3 = new TestSpaceObject("id_3", "message3");
 
 		gigaSpace.writeMultiple(new TestSpaceObject[] {object1, object2, object3}, WriteModifiers.WRITE_ONLY);
 
-		await().until(() -> mongo.findAll(TestSpaceObject.class), containsInAnyOrder(object1, object2, object3));
+		await().until(() -> mongo.findAll(TestSpaceObject.class), containsInAnyOrder(
+				new TestSpaceObject("id_1", "message1"),
+				new TestSpaceObject("id_2", "message2"),
+				new TestSpaceObject("id_3", "message3")
+		));
 	}
 
 	@Test

--- a/ymer/src/test/java/com/avanza/ymer/YmerBulkMirrorIntegrationTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/YmerBulkMirrorIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package com.avanza.ymer;
 
+import static com.avanza.ymer.TestSpaceMirrorObjectDefinitions.TEST_SPACE_OBJECT;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItems;
@@ -43,7 +44,7 @@ public class YmerBulkMirrorIntegrationTest extends YmerMirrorIntegrationTestBase
 		TestSpaceObject object2 = new TestSpaceObject("id_2", "message2");
 
 		// This will cause the insert to fail on this object as it already exists in mongo when added to the gigaspace
-		mongo.insert(object1, TestSpaceMirrorObjectDefinitions.TEST_SPACE_OBJECT.collectionName());
+		mongo.insert(object1, TEST_SPACE_OBJECT.collectionName());
 
 		// This object would not be written if no retries are made
 		TestSpaceObject object3 = new TestSpaceObject("id_3", "message3");
@@ -61,9 +62,7 @@ public class YmerBulkMirrorIntegrationTest extends YmerMirrorIntegrationTestBase
 		gigaSpace.writeMultiple(new TestSpaceObject[] {object1, object2}, WriteModifiers.WRITE_ONLY);
 		await().until(() -> mongo.findAll(TestSpaceObject.class), hasItems(object1, object2));
 
-		mongo.remove(new Query().addCriteria(where("_id").is("id_1")),
-				TestSpaceMirrorObjectDefinitions.TEST_SPACE_OBJECT.collectionName()
-		);
+		mongo.remove(new Query().addCriteria(where("_id").is("id_1")), TEST_SPACE_OBJECT.collectionName());
 
 		object2.setMessage("test");
 

--- a/ymer/src/test/java/com/avanza/ymer/YmerMirrorIntegrationTestBase.java
+++ b/ymer/src/test/java/com/avanza/ymer/YmerMirrorIntegrationTestBase.java
@@ -282,6 +282,9 @@ public abstract class YmerMirrorIntegrationTestBase {
 		}
 		mirrorPu.start();
 
+		// Reconfigure test case for restarted Mirror PU
+		configureTestCase(pu, mirrorPu);
+
 		// Arrange
 		final TestSpaceObject o1 = new TestSpaceObject("id1", "message");
 		gigaSpace.write(o1);

--- a/ymer/src/test/java/com/avanza/ymer/helper/FakeBatchData.java
+++ b/ymer/src/test/java/com/avanza/ymer/helper/FakeBatchData.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer.helper;
+
+import com.gigaspaces.sync.DataSyncOperation;
+import com.gigaspaces.sync.OperationsBatchData;
+import com.gigaspaces.sync.SynchronizationSourceDetails;
+
+public class FakeBatchData implements OperationsBatchData {
+
+	private final DataSyncOperation[] batchDataItems;
+
+	public FakeBatchData(FakeBulkItem[] items) {
+		batchDataItems = items;
+	}
+
+	public static FakeBatchData create(FakeBulkItem... items) {
+		return new FakeBatchData(items);
+	}
+
+	@Override
+	public DataSyncOperation[] getBatchDataItems() {
+		return this.batchDataItems;
+	}
+
+	@Override
+	public SynchronizationSourceDetails getSourceDetails() {
+		return () -> "spaceName_container1_1:spaceName";
+	}
+
+}

--- a/ymer/src/test/java/com/avanza/ymer/helper/FakeBulkItem.java
+++ b/ymer/src/test/java/com/avanza/ymer/helper/FakeBulkItem.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.avanza.ymer.helper;
+
+import com.gigaspaces.document.SpaceDocument;
+import com.gigaspaces.metadata.SpaceTypeDescriptor;
+import com.gigaspaces.sync.DataSyncOperation;
+import com.gigaspaces.sync.DataSyncOperationType;
+
+public class FakeBulkItem implements DataSyncOperation {
+
+	private final Object item;
+	private final DataSyncOperationType operation;
+
+	public FakeBulkItem(Object item, DataSyncOperationType operation) {
+		this.item = item;
+		this.operation = operation;
+	}
+
+	@Override
+	public Object getDataAsObject() {
+		return this.item;
+	}
+
+	@Override
+	public DataSyncOperationType getDataSyncOperationType() {
+		return operation;
+	}
+
+	@Override
+	public Object getSpaceId() {
+		return null;
+	}
+
+	@Override
+	public SpaceTypeDescriptor getTypeDescriptor() {
+		return null;
+	}
+
+	@Override
+	public String getUid() {
+		return null;
+	}
+
+	@Override
+	public boolean supportsDataAsDocument() {
+		return false;
+	}
+
+	@Override
+	public boolean supportsDataAsObject() {
+		return false;
+	}
+
+	@Override
+	public boolean supportsGetSpaceId() {
+		return false;
+	}
+
+	@Override
+	public boolean supportsGetTypeDescriptor() {
+		return false;
+	}
+
+	@Override
+	public SpaceDocument getDataAsDocument() {
+		return null;
+	}
+}


### PR DESCRIPTION
* Adds statistics from https://github.com/AvanzaBank/ymer/pull/96 to the new `BulkMirroredObjectWriter`
* Handle counting failure statistics for document conversion when retries occur
* Add tests verifying the statistics are calculated correctly

---
Targets https://github.com/AvanzaBank/ymer/pull/97 as that branch can't be merged to `main` branch without these fixes. I created this as a separate PR to not any more logic to review in the earlier PR.
