### PR TITLE
TP-1229: Make using bulkWrite default

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/MirroredObjectWriter.java
+++ b/ymer/src/main/java/com/avanza/ymer/MirroredObjectWriter.java
@@ -37,7 +37,11 @@ import com.gigaspaces.sync.OperationsBatchData;
 
 /**
  * @author Elias Lindholm (elilin)
+ *
+ * @deprecated Usage of this slower writer is not recommended.
+ * The much faster {@link BulkMirroredObjectWriter} should be used instead.
  */
+@Deprecated
 final class MirroredObjectWriter {
 
 	private final SpaceMirrorContext mirror;

--- a/ymer/src/main/java/com/avanza/ymer/ReloadableYmerProperties.java
+++ b/ymer/src/main/java/com/avanza/ymer/ReloadableYmerProperties.java
@@ -49,7 +49,7 @@ public final class ReloadableYmerProperties {
 
 	public static final class ReloadablePropertiesBuilder {
 		private Supplier<Optional<Integer>> nextNumberOfInstances = Optional::empty;
-		private BooleanSupplier useBulkWrites = () -> false;
+		private BooleanSupplier useBulkWrites = () -> true;
 
 		private ReloadablePropertiesBuilder() {
 		}
@@ -70,6 +70,7 @@ public final class ReloadableYmerProperties {
 
 		/**
 		 * Enable this to use {@link BulkMirroredObjectWriter} instead of {@link MirroredObjectWriter} for writes.
+		 * This is default {@code true} and not using bulkWrites is deprecated and will be removed in a future version.
 		 */
 		public ReloadablePropertiesBuilder useBulkWrites(BooleanSupplier useBulkWrites) {
 			this.useBulkWrites = useBulkWrites;

--- a/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
+++ b/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
@@ -49,6 +49,7 @@ final class YmerSpaceSynchronizationEndpoint extends SpaceSynchronizationEndpoin
 	private static final Logger log = LoggerFactory.getLogger(YmerSpaceSynchronizationEndpoint.class);
 	private static final ThreadFactory THREAD_FACTORY = new CustomizableThreadFactory("Ymer-Space-Synchronization-Endpoint-");
 
+	@SuppressWarnings("deprecation")
 	private final MirroredObjectWriter mirroredObjectWriter;
 	private final BulkMirroredObjectWriter bulkMirroredObjectWriter;
 	private final ToggleableDocumentWriteExceptionHandler exceptionHandler;

--- a/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
+++ b/ymer/src/main/java/com/avanza/ymer/YmerSpaceSynchronizationEndpoint.java
@@ -63,6 +63,7 @@ final class YmerSpaceSynchronizationEndpoint extends SpaceSynchronizationEndpoin
 
 	private final PerformedOperationMetrics operationStatistics;
 
+	@SuppressWarnings("deprecation")
 	public YmerSpaceSynchronizationEndpoint(SpaceMirrorContext spaceMirror, ReloadableYmerProperties ymerProperties) {
 		exceptionHandler = ToggleableDocumentWriteExceptionHandler.create(
 				new RethrowsTransientDocumentWriteExceptionHandler(),

--- a/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/MirroredObjectWriterTest.java
@@ -36,6 +36,7 @@ import com.avanza.ymer.helper.FakeBulkItem;
 import com.avanza.ymer.helper.MirrorExceptionSpy;
 import com.gigaspaces.sync.DataSyncOperationType;
 
+@Deprecated
 public class MirroredObjectWriterTest {
 
 	private final FakeDocumentWriteExceptionHandler exceptionHandler = new FakeDocumentWriteExceptionHandler();

--- a/ymer/src/test/java/com/avanza/ymer/YmerNonBulkMirrorIntegrationTest.java
+++ b/ymer/src/test/java/com/avanza/ymer/YmerNonBulkMirrorIntegrationTest.java
@@ -19,7 +19,10 @@ import com.avanza.gs.test.RunningPu;
 
 /**
  * These tests use {@link MirroredObjectWriter} for persisting to MongoDB.
+ *
+ * @deprecated This test is not needed anymore when MirroredObjectWriter is removed
  */
+@Deprecated
 public class YmerNonBulkMirrorIntegrationTest extends YmerMirrorIntegrationTestBase {
 
 	@Override


### PR DESCRIPTION
* Using bulkWrite for writing is now the default option
* Deprecated the old `MirroredObjectWriter`