### PR TITLE
TP-1249: Fix handling of complex key in bulkWrite

### DIFF
--- a/ymer/src/main/java/com/avanza/ymer/BulkMirroredObjectWriter.java
+++ b/ymer/src/main/java/com/avanza/ymer/BulkMirroredObjectWriter.java
@@ -190,9 +190,13 @@ final class BulkMirroredObjectWriter {
 	}
 
 	private void addResultToStatistics(BulkWriteResult result) {
-		operationsListener.increment(OperationType.INSERT, result.getInsertedCount());
-		operationsListener.increment(OperationType.UPDATE, result.getMatchedCount());
-		operationsListener.increment(OperationType.DELETE, result.getDeletedCount());
+		try {
+			operationsListener.increment(OperationType.INSERT, result.getInsertedCount());
+			operationsListener.increment(OperationType.UPDATE, result.getMatchedCount());
+			operationsListener.increment(OperationType.DELETE, result.getDeletedCount());
+		} catch (Exception e) {
+			logger.warn("Error while adding bulk write result to statistics", e);
+		}
 	}
 
 	private void checkBulkResultForWarnings(int expectedInsertions, int expectedUpdates, int expectedRemovals, BulkWriteResult result) {

--- a/ymer/src/main/java/com/avanza/ymer/BulkMirroredObjectWriter.java
+++ b/ymer/src/main/java/com/avanza/ymer/BulkMirroredObjectWriter.java
@@ -156,8 +156,11 @@ final class BulkMirroredObjectWriter {
 			});
 
 			addResultToStatistics(result);
-			checkBulkResultForWarnings(insertions.intValue(), updates.intValue(), removals.intValue(), result);
-
+			try {
+				checkBulkResultForWarnings(insertions.intValue(), updates.intValue(), removals.intValue(), result);
+			} catch (Exception e) {
+				logger.warn("Error while checking for warnings in bulkWrite result", e);
+			}
 			return emptyList();
 		} catch (MongoBulkWriteException e) {
 			addResultToStatistics(e.getWriteResult());
@@ -213,7 +216,7 @@ final class BulkMirroredObjectWriter {
 			if (!result.getUpserts().isEmpty()) {
 				warningMessage.append("The following ids were inserted by upsert into MongoDB as a result of update operations: [")
 						.append(result.getUpserts().stream()
-								.map(bson -> bson.getId().asString().getValue())
+								.map(bson -> bson.getId().toString())
 								.collect(joining(", ")))
 						.append("].");
 			} else {

--- a/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
+++ b/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
@@ -54,8 +54,7 @@ public class TestSpaceMirrorObjectDefinitions implements MirroredObjectsConfigur
 
 	public static final MirroredObjectDefinition<SpaceObjectWithComplexKey> TEST_OBJECT_WITH_COMPLEX_KEY =
 			MirroredObjectDefinition.create(SpaceObjectWithComplexKey.class)
-					.loadDocumentsRouted(true)
-					.persistInstanceId(true);
+					.loadDocumentsRouted(true);
 
 	@Override
 	public Collection<MirroredObjectDefinition<?>> getMirroredObjectDefinitions() {

--- a/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
+++ b/ymer/src/test/java/com/avanza/ymer/TestSpaceMirrorObjectDefinitions.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 
 import com.avanza.ymer.YmerInitialLoadIntegrationTest.TestSpaceObjectV1Patch;
 import com.avanza.ymer.YmerInitialLoadIntegrationTest.TestSpaceObjectV2Patch;
+import com.avanza.ymer.space.SpaceObjectWithComplexKey;
 
 public class TestSpaceMirrorObjectDefinitions implements MirroredObjectsConfiguration {
 
@@ -51,6 +52,11 @@ public class TestSpaceMirrorObjectDefinitions implements MirroredObjectsConfigur
 	public static final MirroredObjectDefinition<TestReloadableSpaceObject> TEST_RELOADABLE_OBJECT =
 			MirroredObjectDefinition.create(TestReloadableSpaceObject.class);
 
+	public static final MirroredObjectDefinition<SpaceObjectWithComplexKey> TEST_OBJECT_WITH_COMPLEX_KEY =
+			MirroredObjectDefinition.create(SpaceObjectWithComplexKey.class)
+					.loadDocumentsRouted(true)
+					.persistInstanceId(true);
+
 	@Override
 	public Collection<MirroredObjectDefinition<?>> getMirroredObjectDefinitions() {
 		return Arrays.asList(
@@ -58,7 +64,8 @@ public class TestSpaceMirrorObjectDefinitions implements MirroredObjectsConfigur
 				TEST_SPACE_OTHER_OBJECT,
 				TEST_SPACE_THIRD_OBJECT,
 				TEST_SPACE_OBJECT_CUSTOM_ROUTINGKEY,
-				TEST_RELOADABLE_OBJECT
+				TEST_RELOADABLE_OBJECT,
+				TEST_OBJECT_WITH_COMPLEX_KEY
 		);
 	}
 }

--- a/ymer/src/test/java/com/avanza/ymer/space/ComplexId.java
+++ b/ymer/src/test/java/com/avanza/ymer/space/ComplexId.java
@@ -1,0 +1,59 @@
+package com.avanza.ymer.space;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ComplexId implements Serializable {
+
+	private String key1;
+	private Integer key2;
+
+	public ComplexId() {
+	}
+
+	public ComplexId(String key1, Integer key2) {
+		this.key1 = key1;
+		this.key2 = key2;
+	}
+
+	public String getKey1() {
+		return key1;
+	}
+
+	public void setKey1(String key1) {
+		this.key1 = key1;
+	}
+
+	public Integer getKey2() {
+		return key2;
+	}
+
+	public void setKey2(Integer key2) {
+		this.key2 = key2;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ComplexId complexId = (ComplexId) o;
+		return Objects.equals(getKey1(), complexId.getKey1()) && Objects.equals(getKey2(), complexId.getKey2());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getKey1(), getKey2());
+	}
+
+	@Override
+	public String toString() {
+		return "ComplexId{" +
+				"key1='" + key1 + '\'' +
+				", key2=" + key2 +
+				'}';
+	}
+}

--- a/ymer/src/test/java/com/avanza/ymer/space/ComplexId.java
+++ b/ymer/src/test/java/com/avanza/ymer/space/ComplexId.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.avanza.ymer.space;
 
 import java.io.Serializable;

--- a/ymer/src/test/java/com/avanza/ymer/space/SpaceObjectWithComplexKey.java
+++ b/ymer/src/test/java/com/avanza/ymer/space/SpaceObjectWithComplexKey.java
@@ -1,0 +1,68 @@
+package com.avanza.ymer.space;
+
+import java.util.Objects;
+
+import org.springframework.data.annotation.Id;
+
+import com.gigaspaces.annotation.pojo.SpaceClass;
+import com.gigaspaces.annotation.pojo.SpaceId;
+import com.gigaspaces.annotation.pojo.SpaceRouting;
+
+@SpaceClass
+public class SpaceObjectWithComplexKey {
+
+	@Id
+	private ComplexId id;
+	private String message;
+
+	public SpaceObjectWithComplexKey() {
+	}
+
+	public SpaceObjectWithComplexKey(ComplexId id, String message) {
+		this.id = id;
+		this.message = message;
+	}
+
+	@SpaceId
+	@SpaceRouting
+	public ComplexId getId() {
+		return id;
+	}
+
+	public void setId(ComplexId id) {
+		this.id = id;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		SpaceObjectWithComplexKey that = (SpaceObjectWithComplexKey) o;
+		return Objects.equals(getId(), that.getId()) && Objects.equals(getMessage(), that.getMessage());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getId(), getMessage());
+	}
+
+	@Override
+	public String toString() {
+		return "SpaceObjectWithComplexKey{" +
+				"id=" + id +
+				", message='" + message + '\'' +
+				'}';
+	}
+}

--- a/ymer/src/test/java/com/avanza/ymer/space/SpaceObjectWithComplexKey.java
+++ b/ymer/src/test/java/com/avanza/ymer/space/SpaceObjectWithComplexKey.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.avanza.ymer.space;
 
 import java.util.Objects;


### PR DESCRIPTION
* Complex keys would result in an exception thrown by `bson.getId().asString()`
* Instead, just use `toString()` conversion
* Also, add an extra guard to `checkBulkResultForWarnings` to not propagate errors from this method