### PR TITLE
TP-1276: Remove unnecessary dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 		<log4j.version>2.17.2</log4j.version>
 		<gigaspaces.version>16.1.1</gigaspaces.version>
 		<jsr305.version>3.0.2</jsr305.version>
-		<gs-test.version>2.1.1</gs-test.version>
+		<gs-test.version>2.1.6</gs-test.version>
 		<testcontainers.version>1.17.2</testcontainers.version>
 		<system-stubs.version>2.0.1</system-stubs.version>
 
@@ -177,6 +177,20 @@
 				<groupId>org.gigaspaces</groupId>
 				<artifactId>xap-datagrid</artifactId>
 				<version>${gigaspaces.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>com.github.oshi</groupId>
+						<artifactId>oshi-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.junit.jupiter</groupId>
+						<artifactId>*</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.xerial</groupId>
+						<artifactId>sqlite-jdbc</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.google.code.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
 		<log4j.version>2.17.2</log4j.version>
 		<gigaspaces.version>16.1.1</gigaspaces.version>
 		<jsr305.version>3.0.2</jsr305.version>
-		<gs-test.version>2.1.6</gs-test.version>
+		<gs-test.version>2.1.7</gs-test.version>
 		<testcontainers.version>1.17.2</testcontainers.version>
 		<system-stubs.version>2.0.1</system-stubs.version>
 

--- a/ymer/pom.xml
+++ b/ymer/pom.xml
@@ -92,5 +92,15 @@
             <artifactId>system-stubs-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This removes transitive dependencies on:
* `org.xerial:sqlite-jdbc` (this is one huge artifact)
* `org.junit.jupiter:junit-jupiter-params` (this should not be a compile-scoped dependency)
* `com.github.oshi:oshi-core` (unused and unnecessary)

Also:
* Added missing dependency to `junit-jupiter` (was previously relying on transitive junit-jupiter from gigaspaces).
* Bumped version of `gs-test` to latest.