### PR TITLE
TP-1295: Update mongo-java-driver to 3.8.2

### DIFF
--- a/examples/example-tests/pom.xml
+++ b/examples/example-tests/pom.xml
@@ -22,15 +22,16 @@
 			<groupId>com.avanza.gs</groupId>
 			<artifactId>gs-test</artifactId>
 			<scope>test</scope>
-		</dependency>		
-		<dependency>
-			<groupId>com.github.fakemongo</groupId>
-			<artifactId>fongo</artifactId>
-			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>de.bwaldvogel</groupId>
+			<artifactId>mongo-java-server</artifactId>
+			<version>1.40.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/examples/example-tests/src/test/java/example/tests/InMemoryMongoServer.java
+++ b/examples/example-tests/src/test/java/example/tests/InMemoryMongoServer.java
@@ -1,0 +1,47 @@
+package example.tests;
+/*
+ * Copyright 2015 Avanza Bank AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.bwaldvogel.mongo.MongoServer;
+import de.bwaldvogel.mongo.backend.memory.MemoryBackend;
+
+final class InMemoryMongoServer {
+
+	private static final Logger LOG = LoggerFactory.getLogger(InMemoryMongoServer.class);
+
+	static final String DEFAULT_MONGODB_HOST = "localhost";
+	static final int DEFAULT_MONGODB_PORT = 27017;
+
+	private InMemoryMongoServer() {}
+
+	public static MongoServer getInstance() {
+		return getInstance(DEFAULT_MONGODB_HOST, DEFAULT_MONGODB_PORT);
+	}
+
+	public static MongoServer getInstance(final int port) {
+		return getInstance(DEFAULT_MONGODB_HOST, port);
+	}
+
+	private static MongoServer getInstance(final String host, final int port) {
+		MongoServer mongoServer = new MongoServer(new MemoryBackend());
+		LOG.info("Setting up MongoServer with host={} port={}...", host, port);
+		mongoServer.bind(host, port);
+		return mongoServer;
+	}
+}

--- a/examples/example-tests/src/test/java/example/tests/InitialLoadTest.java
+++ b/examples/example-tests/src/test/java/example/tests/InitialLoadTest.java
@@ -41,36 +41,40 @@ import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
 
 import com.avanza.gs.test.PuConfigurers;
 import com.avanza.gs.test.RunningPu;
-import com.github.fakemongo.Fongo;
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
 
+import de.bwaldvogel.mongo.MongoServer;
 import example.domain.SpaceCar;
 import example.domain.SpaceFruit;
 
 public class InitialLoadTest {
-	
-	private Fongo fongo = new Fongo("fongoDb");
+
+	private MongoServer mongoServer = InMemoryMongoServer.getInstance();
+	private MongoClient mongoClient = new MongoClient(new ServerAddress(mongoServer.getLocalAddress()));
 	private RunningPu pu;
 
 	@After
 	public void shutdownPus() throws Exception {
 		closeSafe(pu);
+		mongoClient.close();
+		mongoServer.shutdownNow();
 	}
 	
 	@Test
 	public void intialLoadDemo() throws Exception {
 		BasicDBObject banana = new BasicDBObject("_id", "banana");
 		banana.put("origin", "Brazil");
-		fongo.getDB("exampleDb").getCollection("spaceFruit").insert(banana);
+		mongoClient.getDB("exampleDb").getCollection("spaceFruit").insert(banana);
 		BasicDBObject apple = new BasicDBObject("_id", "apple");
 		apple.put("origin", "France");
-		fongo.getDB("exampleDb").getCollection("spaceFruit").insert(apple);
-		fongo.getDB("exampleDb").getCollection("spaceCar").insert(new BasicDBObject("name", "Volvo")); // SpaceCar is not Mirrored
+		mongoClient.getDB("exampleDb").getCollection("spaceFruit").insert(apple);
+		mongoClient.getDB("exampleDb").getCollection("spaceCar").insert(new BasicDBObject("name", "Volvo")); // SpaceCar is not Mirrored
 		
 		
 		pu = PuConfigurers.partitionedPu("classpath:example-pu.xml")
-								    .parentContext(createSingleInstanceAppContext(fongo.getMongo()))
+								    .parentContext(createSingleInstanceAppContext(mongoClient))
 								    .configure();
 		
 		pu.start();

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
 			<dependency>
 				<groupId>org.mongodb</groupId>
 				<artifactId>mongo-java-driver</artifactId>
-				<version>3.4.3</version>
+				<version>3.8.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.data</groupId>
@@ -210,7 +210,7 @@
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.11</version>
+				<version>4.13.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>
@@ -226,11 +226,6 @@
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-log4j12</artifactId>
 				<version>${slf4j.version}</version>
-			</dependency>
-			<dependency>
-		  		<groupId>com.github.fakemongo</groupId>
-		  		<artifactId>fongo</artifactId>
-		  		<version>2.1.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.awaitility</groupId>


### PR DESCRIPTION
* Fongo does not work with version 3.8.2, hence the test implementation is changed to use mongo-java-server instead.